### PR TITLE
MUL-228: BTC integration.

### DIFF
--- a/multy_core/CMakeLists.txt
+++ b/multy_core/CMakeLists.txt
@@ -28,6 +28,14 @@ add_library(multy_core
 )
 
 target_compile_definitions(multy_core PRIVATE BUILDING_MULTY_CORE=1)
+target_compile_definitions(multy_core PRIVATE
+    MULTY_CORE_VERSION_MAJOR=0
+    MULTY_CORE_VERSION_MINOR=1
+    MULTY_CORE_VERSION_BUILD=0
+    MULTY_CORE_VERSION_NOTE="PRE-ALPHA-TESTNET"
+    MULTY_CORE_VERSION_COMMIT=""
+)
+
 target_include_directories(multy_core PRIVATE
     ..
     ../third-party/libwally-core/include/

--- a/multy_core/common.h
+++ b/multy_core/common.h
@@ -36,6 +36,23 @@ struct BinaryData
     size_t len;
 };
 
+struct Version
+{
+    size_t major;
+    size_t minor;
+    size_t build;
+    const char* note;  /// can be null
+    const char* commit; /// can be null
+};
+
+MULTY_CORE_API struct Error* get_version(struct Version* version);
+
+/** Generates a version string from version object.
+ * @param version_string - out, version string, must be freed with free_string().
+ * @return Error on error, nullptr otherwise.
+ */
+MULTY_CORE_API struct Error* make_version_string(const char** out_version_string);
+
 /** Frees BinaryData, can take null. **/
 MULTY_CORE_API void free_binarydata(struct BinaryData*);
 

--- a/multy_core/internal/account.cpp
+++ b/multy_core/internal/account.cpp
@@ -6,8 +6,32 @@
 
 #include "multy_core/internal/account.h"
 
+namespace
+{
+const int32_t ACCOUNT_MAGIC = __LINE__;
+const int32_t HD_ACCOUNT_MAGIC = __LINE__;
+} // namespace
+
+Account::Account()
+    : m_magic(&ACCOUNT_MAGIC)
+{}
+
 Account::~Account()
+{}
+
+bool Account::is_valid() const
+{
+    return m_magic == &ACCOUNT_MAGIC;
+}
+
+HDAccount::HDAccount()
+    : m_magic(&HD_ACCOUNT_MAGIC)
 {}
 
 HDAccount::~HDAccount()
 {}
+
+bool HDAccount::is_valid() const
+{
+    return m_magic == &HD_ACCOUNT_MAGIC;
+}

--- a/multy_core/internal/account.h
+++ b/multy_core/internal/account.h
@@ -26,6 +26,7 @@ public:
     typedef wallet_core::internal::PrivateKeyPtr PrivateKeyPtr;
     typedef wallet_core::internal::PublicKeyPtr PublicKeyPtr;
 
+    Account();
     virtual ~Account();
 
     virtual HDPath get_path() const = 0;
@@ -33,6 +34,11 @@ public:
     virtual std::string get_address() const = 0;
     virtual PrivateKeyPtr get_private_key() const = 0;
     virtual PublicKeyPtr get_public_key() const = 0;
+
+    bool is_valid() const;
+
+private:
+    const void* m_magic;
 };
 
 // Exported only to make testing easier.
@@ -42,11 +48,17 @@ public:
     typedef wallet_core::internal::AccountPtr AccountPtr;
     typedef wallet_core::internal::HDPath HDPath;
 
+    HDAccount();
+
     virtual HDPath get_path() const = 0;
     virtual Currency get_currency() const = 0;
 
     virtual ~HDAccount();
     virtual AccountPtr make_leaf_account(AddressType type, uint32_t index) const = 0;
+
+    bool is_valid() const;
+private:
+    const void* m_magic;
 };
 
 #endif // MULTY_CORE_INTERNAL_ACCOUNT_H

--- a/multy_core/internal/key.cpp
+++ b/multy_core/internal/key.cpp
@@ -12,6 +12,16 @@
 #include "wally_bip32.h"
 #include "wally_core.h"
 
+namespace
+{
+const int32_t EXTENDED_KEY_MAGIC = __LINE__;
+const int32_t KEY_MAGIC = __LINE__;
+} // namespace
+
+ExtendedKey::ExtendedKey()
+    : m_magic(&EXTENDED_KEY_MAGIC)
+{}
+
 std::string ExtendedKey::to_string() const
 {
     using namespace wallet_core::internal;
@@ -30,8 +40,22 @@ std::string ExtendedKey::to_string() const
     return std::string(out_str.get());
 }
 
+bool ExtendedKey::is_valid() const
+{
+    return m_magic == &EXTENDED_KEY_MAGIC;
+}
+
+Key::Key()
+    : m_magic(&KEY_MAGIC)
+{}
+
 Key::~Key()
 {
+}
+
+bool Key::is_valid() const
+{
+    return m_magic == &KEY_MAGIC;
 }
 
 PrivateKey::~PrivateKey()

--- a/multy_core/internal/key.h
+++ b/multy_core/internal/key.h
@@ -20,19 +20,33 @@ struct PublicKey;
 
 struct MULTY_CORE_API ExtendedKey
 {
-    ext_key key;
+    ExtendedKey();
 
     std::string to_string() const;
+
+    bool is_valid() const;
+
+public:
+    ext_key key;
+
+private:
+    const void* m_magic;
 };
 
 struct MULTY_CORE_API Key
 {
+    Key();
     virtual ~Key();
 
     virtual std::string to_string() const = 0;
 
 //    virtual wallet_core::internal::BinaryDataPtr encrypt(const BinaryData* data) const = 0;
 //    virtual wallet_core::internal::BinaryDataPtr decrypt(const BinaryData* data) const = 0;
+
+    bool is_valid() const;
+
+private:
+    const void* m_magic;
 };
 
 struct MULTY_CORE_API PrivateKey : public Key

--- a/multy_core/internal/utility.h
+++ b/multy_core/internal/utility.h
@@ -12,8 +12,8 @@
  */
 
 #include "multy_core/api.h"
-#include "multy_core/error.h"
 #include "multy_core/common.h"
+#include "multy_core/error.h"
 #include "multy_core/internal/u_ptr.h"
 
 #include <memory>
@@ -45,6 +45,30 @@ struct Error;
     {                                                                          \
         return wallet_core::internal::exception_to_error();                    \
     }
+
+#define CHECK_OBJECT(obj)                                                      \
+    do                                                                         \
+    {                                                                          \
+        if (!(obj)->is_valid())                                                \
+        {                                                                      \
+            return make_error(                                                 \
+                    ERROR_INVALID_ARGUMENT, #obj " is not a valid object.");   \
+        }                                                                      \
+    } while (false)
+
+#define ARG_CHECK_OBJECT(obj)                                                  \
+    do                                                                         \
+    {                                                                          \
+        ARG_CHECK((obj) != nullptr);                                           \
+        CHECK_OBJECT((obj));                                                   \
+    } while (false)
+
+#define OUT_CHECK_OBJECT(obj)                                                  \
+    do                                                                         \
+    {                                                                          \
+        OUT_CHECK((obj) != nullptr);                                           \
+        CHECK_OBJECT((obj));                                                   \
+    } while (false)
 
 namespace wallet_core
 {

--- a/multy_core/mnemonic.h
+++ b/multy_core/mnemonic.h
@@ -44,9 +44,6 @@ MULTY_CORE_API struct Error* seed_to_string(
 MULTY_CORE_API struct Error* mnemonic_get_dictionary(
         const char** new_dictionary);
 
-/** Frees mnemonic, can take nullptr. **/
-MULTY_CORE_API void free_mnemonic(const char* mnemonic);
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/multy_core/src/account.cpp
+++ b/multy_core/src/account.cpp
@@ -59,7 +59,7 @@ Error* make_hd_account(
     {
         return exception_to_error();
     }
-    OUT_CHECK(*new_account);
+    OUT_CHECK_OBJECT(*new_account);
 
     return nullptr;
 }
@@ -70,7 +70,7 @@ Error* make_hd_leaf_account(
         uint32_t index,
         Account** new_account)
 {
-    ARG_CHECK(base_account);
+    ARG_CHECK_OBJECT(base_account);
     ARG_CHECK(address_type == ADDRESS_INTERNAL
             || address_type == ADDRESS_EXTERNAL);
     ARG_CHECK(index < HARDENED_INDEX_BASE);
@@ -85,7 +85,7 @@ Error* make_hd_leaf_account(
     {
         return exception_to_error();
     }
-    OUT_CHECK(*new_account);
+    OUT_CHECK_OBJECT(*new_account);
 
     return nullptr;
 }
@@ -127,14 +127,14 @@ Error* make_account(
     {
         return exception_to_error();
     }
-    OUT_CHECK(*new_account);
+    OUT_CHECK_OBJECT(*new_account);
 
     return nullptr;
 }
 
 Error* get_account_key(const Account* account, KeyType key_type, Key** out_key)
 {
-    ARG_CHECK(account != nullptr);
+    ARG_CHECK_OBJECT(account);
     ARG_CHECK(key_type == KEY_TYPE_PRIVATE || key_type == KEY_TYPE_PUBLIC);
     ARG_CHECK(out_key != nullptr);
 
@@ -161,7 +161,7 @@ Error* get_account_key(const Account* account, KeyType key_type, Key** out_key)
 Error* get_account_address_string(
         const Account* account, const char** out_address)
 {
-    ARG_CHECK(account);
+    ARG_CHECK_OBJECT(account);
     ARG_CHECK(out_address);
 
     try
@@ -180,7 +180,7 @@ Error* get_account_address_string(
 Error* get_account_address_path(
         const Account* account, const char** out_address_path)
 {
-    ARG_CHECK(account);
+    ARG_CHECK_OBJECT(account);
     ARG_CHECK(out_address_path);
 
     try
@@ -198,7 +198,7 @@ Error* get_account_address_path(
 
 Error* get_account_currency(const Account* account, Currency* out_currency)
 {
-    ARG_CHECK(account);
+    ARG_CHECK_OBJECT(account);
     ARG_CHECK(out_currency);
 
     try
@@ -215,10 +215,12 @@ Error* get_account_currency(const Account* account, Currency* out_currency)
 
 void free_hdaccount(HDAccount* account)
 {
+    // TODO: if account is non-null, do verify validity.
     delete account;
 }
 
 void free_account(Account* account)
 {
+    // TODO: if account is non-null, do verify validity.
     delete account;
 }

--- a/multy_core/src/common.cpp
+++ b/multy_core/src/common.cpp
@@ -12,23 +12,86 @@
 #include "wally_core.h"
 
 #include <string.h>
+#include <sstream>
+
+#ifndef MULTY_CORE_VERSION_MAJOR
+#define MULTY_CORE_VERSION_MAJOR 0
+#endif // MULTY_CORE_VERSION_MAJOR
+
+#ifndef MULTY_CORE_VERSION_MINOR
+#define MULTY_CORE_VERSION_MINOR 0
+#endif // MULTY_CORE_VERSION_MINOR
+
+#ifndef MULTY_CORE_VERSION_BUILD
+#define MULTY_CORE_VERSION_BUILD 0
+#endif // MULTY_CORE_VERSION_BUILD
+
+#ifndef MULTY_CORE_VERSION_NOTE
+#define MULTY_CORE_VERSION_NOTE ""
+#endif // MULTY_CORE_VERSION_NOTE
+
+#ifndef MULTY_CORE_VERSION_COMMIT
+#define MULTY_CORE_VERSION_COMMIT ""
+#endif // MULTY_CORE_VERSION_COMMIT
 
 namespace
 {
 using namespace wallet_core::internal;
+
+const Version CURRENT_VERSION = {
+    MULTY_CORE_VERSION_MAJOR,
+    MULTY_CORE_VERSION_MINOR,
+    MULTY_CORE_VERSION_BUILD,
+    MULTY_CORE_VERSION_NOTE,
+    MULTY_CORE_VERSION_COMMIT
+};
+
+std::string format_version(const Version& version)
+{
+    std::stringstream sstr;
+    sstr << version.major << "." << version.minor << "." << version.build;
+    if (version.note && strlen(version.note))
+    {
+        sstr << "-" << version.note;
+    }
+    if (version.commit && strlen(version.commit))
+    {
+        sstr << "(" << version.commit << ")";
+    }
+    return sstr.str();
+}
+
+} // namespace
+
+Error* get_version(Version* version)
+{
+    ARG_CHECK(version);
+    *version = CURRENT_VERSION;
+    return nullptr;
+}
+
+Error* make_version_string(const char** out_version_string)
+{
+    ARG_CHECK(out_version_string);
+    try
+    {
+        *out_version_string = copy_string(format_version(CURRENT_VERSION));
+    }
+    CATCH_EXCEPTION_RETURN_ERROR();
+
+    OUT_CHECK(*out_version_string);
+    return nullptr;
 }
 
 Error* binary_data_clone(const BinaryData* source, BinaryData** new_binary_data)
 {
     ARG_CHECK(source);
-
     return make_binary_data_from_bytes(
             source->data, source->len, new_binary_data);
 }
 
 Error* make_binary_data(size_t size, BinaryData** new_binary_data)
 {
-    ARG_CHECK(size);
     ARG_CHECK(new_binary_data);
     try
     {
@@ -48,14 +111,16 @@ Error* make_binary_data(size_t size, BinaryData** new_binary_data)
 Error* make_binary_data_from_bytes(
         const unsigned char* data, size_t size, BinaryData** new_binary_data)
 {
-    ARG_CHECK(data);
-    ARG_CHECK(size);
+    ARG_CHECK(size == 0 || data);
     ARG_CHECK(new_binary_data);
     try
     {
         BinaryDataPtr result;
         throw_if_error(make_binary_data(size, reset_sp(result)));
-        memcpy(const_cast<unsigned char*>(result->data), data, size);
+        if (result->data && size != 0)
+        {
+            memcpy(const_cast<unsigned char*>(result->data), data, size);
+        }
         *new_binary_data = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR();
@@ -72,18 +137,27 @@ Error* make_binary_data_from_hex(
     ARG_CHECK(new_binary_data);
     try
     {
-        const size_t data_len = strlen(hex_str) / 2;
+        const size_t hex_str_len = strlen(hex_str);
+        if (hex_str_len & 1)
+        {
+            return make_error(ERROR_INVALID_ARGUMENT, "Input string length must be even.");
+        }
+
+        const size_t data_len = hex_str_len / 2;
         BinaryDataPtr result;
         throw_if_error(make_binary_data(data_len, reset_sp(result)));
 
-        size_t real_size = 0;
-        throw_if_wally_error(
-                wally_hex_to_bytes(
-                        hex_str, const_cast<unsigned char*>(result->data),
-                        result->len, &real_size),
-                "Failed to convert hex string to binary data.");
+        if (data_len != 0)
+        {
+            size_t real_size = 0;
+            throw_if_wally_error(
+                    wally_hex_to_bytes(
+                            hex_str, const_cast<unsigned char*>(result->data),
+                            result->len, &real_size),
+                    "Failed to convert hex string to binary data.");
 
-        result->len = real_size;
+            result->len = real_size;
+        }
         *new_binary_data = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR();

--- a/multy_core/src/keys.cpp
+++ b/multy_core/src/keys.cpp
@@ -66,7 +66,7 @@ Error* make_key_id(
         const ExtendedKey* key,
         const char** out_key_id)
 {
-    ARG_CHECK(key);
+    ARG_CHECK_OBJECT(key);
     ARG_CHECK(out_key_id);
     try
     {
@@ -99,7 +99,7 @@ Error* make_child_key(
         uint32_t chain_code,
         ExtendedKey** new_child_key)
 {
-    ARG_CHECK(parent_key);
+    ARG_CHECK_OBJECT(parent_key);
     ARG_CHECK(new_child_key);
 
     try
@@ -125,7 +125,7 @@ Error* make_child_key(
 Error* extended_key_to_string(
         const ExtendedKey* extended_key, const char** new_str)
 {
-    ARG_CHECK(extended_key);
+    ARG_CHECK_OBJECT(extended_key);
     ARG_CHECK(new_str);
 
     try
@@ -144,7 +144,7 @@ Error* extended_key_to_string(
 Error* private_to_public_key(
         const PrivateKey* private_key, PublicKey** new_public_key)
 {
-    ARG_CHECK(private_key);
+    ARG_CHECK_OBJECT(private_key);
     ARG_CHECK(new_public_key);
     try
     {
@@ -161,7 +161,7 @@ Error* private_to_public_key(
 
 Error* key_to_string(const Key* key, const char** new_str)
 {
-    ARG_CHECK(key);
+    ARG_CHECK_OBJECT(key);
     ARG_CHECK(new_str);
     try
     {

--- a/multy_core/src/mnemonic.cpp
+++ b/multy_core/src/mnemonic.cpp
@@ -30,7 +30,7 @@ size_t round_to_supported_entropy_size(size_t entropy_size)
             BIP39_ENTROPY_LEN_320,
     };
 
-    size_t result = 0;
+    size_t result = BIP39_ENTROPY_LEN_320;
     for (size_t i = 0; i < array_size(supported_entropy_sizes); ++i)
     {
         if (entropy_size >= supported_entropy_sizes[i])
@@ -115,6 +115,7 @@ Error* make_seed(const char* mnemonic, const char* password, BinaryData** seed)
 Error* seed_to_string(const BinaryData* seed, const char** str)
 {
     ARG_CHECK(seed);
+    ARG_CHECK(seed->data);
     ARG_CHECK(str);
 
     char* out = nullptr;
@@ -158,13 +159,4 @@ Error* mnemonic_get_dictionary(const char** new_dictionary)
     OUT_CHECK(*new_dictionary);
 
     return nullptr;
-}
-
-void free_mnemonic(const char* mnemonic)
-{
-    if (!mnemonic)
-    {
-        return;
-    }
-    wally_free_string(const_cast<char*>(mnemonic));
 }

--- a/multy_test/CMakeLists.txt
+++ b/multy_test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(multy_test SHARED
     test_account.cpp
     test_bitcoin_account.cpp
     test_bitcoin_transaction.cpp
+    test_common.cpp
     test_ethereum_account.cpp
     test_ethereum_transaction.cpp
     test_keys.cpp

--- a/multy_test/test_common.cpp
+++ b/multy_test/test_common.cpp
@@ -1,0 +1,129 @@
+/* Copyright 2017 by Multy.io
+ * Licensed under Multy.io license
+ *
+ * See LICENSE for details
+ */
+
+#include "multy_core/common.h"
+
+#include "multy_core/internal/u_ptr.h"
+
+#include "multy_test/utility.h"
+
+#include "gtest/gtest.h"
+
+#include <memory>
+
+namespace
+{
+using namespace test_utility;
+using namespace wallet_core::internal;
+
+struct HexTestCase
+{
+    const char* hex_string;
+    bytes hex_data;
+};
+
+const HexTestCase TestCases[] =
+{
+    {
+        "",
+        {}
+    },
+    {
+        "01",
+        {0x01}
+    },
+    {
+        "ffffffff",
+        {0xff, 0xff, 0xff, 0xff}
+    },
+    {
+        "010203040506070809A0B0C0D0E0F0",
+        {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+         0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0}
+    },
+};
+
+const char* InvalidHexTestCases[] = {
+    "q",
+    "-x",
+    "1.1",
+    // 0x prefix is not supported
+    "0x00"
+};
+
+class BinaryDataTestValidHex : public ::testing::TestWithParam<HexTestCase>
+{};
+
+class BinaryDataTestInvalidHex : public ::testing::TestWithParam<const char*>
+{};
+
+TEST_P(BinaryDataTestValidHex, make_binary_data_from_hex)
+{
+    const HexTestCase& param = GetParam();
+
+    BinaryDataPtr result;
+    HANDLE_ERROR(make_binary_data_from_hex(param.hex_string, reset_sp(result)));
+    ASSERT_NE(nullptr, result);
+
+    ASSERT_EQ(to_binary_data(param.hex_data), *result);
+}
+
+TEST_P(BinaryDataTestValidHex, make_binary_data_from_bytes)
+{
+    const HexTestCase& param = GetParam();
+
+    BinaryDataPtr result;
+    HANDLE_ERROR(make_binary_data_from_bytes(
+            param.hex_data.data(), param.hex_data.size(), reset_sp(result)));
+    ASSERT_NE(nullptr, result);
+
+    ASSERT_EQ(to_binary_data(param.hex_data), *result);
+}
+
+TEST_P(BinaryDataTestInvalidHex, make_binary_data_from_hex)
+{
+    const char* param = GetParam();
+
+    BinaryDataPtr result;
+    EXPECT_ERROR(make_binary_data_from_hex(param, reset_sp(result)));
+    EXPECT_EQ(nullptr, result);
+}
+
+INSTANTIATE_TEST_CASE_P(Hex, BinaryDataTestValidHex,
+        ::testing::ValuesIn(TestCases));
+
+INSTANTIATE_TEST_CASE_P(Error, BinaryDataTestInvalidHex,
+        ::testing::ValuesIn(InvalidHexTestCases));
+
+GTEST_TEST(VersionTest, get_version)
+{
+    Version version;
+    HANDLE_ERROR(get_version(&version));
+
+    ASSERT_NE(0, version.major + version.minor + version.build);
+    ASSERT_NE(nullptr, version.note);
+}
+
+GTEST_TEST(VersionTest, make_version_string)
+{
+    ConstCharPtr version_string;
+    HANDLE_ERROR(make_version_string(reset_sp(version_string)));
+
+    ASSERT_NE(nullptr, version_string);
+    std::cerr << "Library version:" << version_string.get() << std::endl;
+}
+
+GTEST_TEST(VersionTestInvalidArgs, get_version)
+{
+    EXPECT_ERROR(get_version(nullptr));
+}
+
+GTEST_TEST(VersionTestInvalidArgs, make_version_string)
+{
+    EXPECT_ERROR(make_version_string(nullptr));
+}
+
+} // namespace

--- a/multy_test/test_transaction.cpp
+++ b/multy_test/test_transaction.cpp
@@ -184,26 +184,28 @@ GTEST_TEST(TransactionTestInvalidArgs, transaction_estimate_fee)
 {
     ErrorPtr error;
     TestTransaction transaction;
-    Amount amount;
+    AmountPtr amount;
 
     error.reset(transaction_estimate_fee(&transaction, nullptr ));
     EXPECT_NE(nullptr, error);
 
-    error.reset(transaction_estimate_fee(nullptr, &amount));
+    error.reset(transaction_estimate_fee(nullptr, reset_sp(amount)));
     EXPECT_NE(nullptr, error);
+    EXPECT_EQ(nullptr, amount);
 }
 
 GTEST_TEST(TransactionTestInvalidArgs, transaction_get_total_fee)
 {
     ErrorPtr error;
     TestTransaction transaction;
-    Amount amount;
+    AmountPtr amount;
 
     error.reset(transaction_get_total_fee(&transaction, nullptr ));
     EXPECT_NE(nullptr, error);
 
-    error.reset(transaction_get_total_fee(nullptr, &amount));
+    error.reset(transaction_get_total_fee(nullptr, reset_sp(amount)));
     EXPECT_NE(nullptr, error);
+    EXPECT_EQ(nullptr, amount);
 }
 
 GTEST_TEST(TransactionTestInvalidArgs, transaction_update)
@@ -307,9 +309,9 @@ GTEST_TEST(TransactionTest, transaction_estimate_fee)
 {
     ErrorPtr error;
     TestTransaction transaction;
-    Amount amount;
+    AmountPtr amount;
 
-    error.reset(transaction_estimate_fee(&transaction, &amount));
+    error.reset(transaction_estimate_fee(&transaction, reset_sp(amount)));
     EXPECT_EQ(nullptr, error);
 }
 
@@ -317,9 +319,9 @@ GTEST_TEST(TransactionTest, transaction_get_total_fee)
 {
     ErrorPtr error;
     TestTransaction transaction;
-    Amount amount;
+    AmountPtr amount;
 
-    error.reset(transaction_get_total_fee(&transaction, &amount));
+    error.reset(transaction_get_total_fee(&transaction, reset_sp(amount)));
     EXPECT_EQ(nullptr, error);
 }
 

--- a/multy_test/test_utility.cpp
+++ b/multy_test/test_utility.cpp
@@ -4,9 +4,6 @@
  * See LICENSE for details
  */
 
-#ifndef TEST_UTILITY_CPP
-#define TEST_UTILITY_CPP
-
 #include "multy_core/internal/utility.h"
 
 #include "gtest/gtest.h"
@@ -55,5 +52,3 @@ GTEST_TEST(UtilityTest, reset_sp)
     p_char.reset();
     EXPECT_EQ(TEST_VALUE2, old_value);
 }
-
-#endif // TEST_UTILITY_CPP

--- a/multy_test/utility.cpp
+++ b/multy_test/utility.cpp
@@ -86,7 +86,7 @@ BinaryData to_binary_data(const char* data)
 ExtendedKey make_dummy_extended_key()
 {
     ExtendedKey result;
-    memset(&result, 0, sizeof(result));
+    memset(&result.key, 0, sizeof(result.key));
     return result;
 }
 

--- a/multy_test/utility.h
+++ b/multy_test/utility.h
@@ -4,8 +4,8 @@
  * See LICENSE for details
  */
 
-#ifndef UTILITY_H
-#define UTILITY_H
+#ifndef MULTY_TEST_UTILITY_H
+#define MULTY_TEST_UTILITY_H
 
 #include "multy_core/common.h"
 #include "multy_core/internal/utility.h"
@@ -18,8 +18,15 @@
 #define HANDLE_ERROR(statement)                                                \
     do                                                                         \
     {                                                                          \
-        error.reset(statement);                                                \
+        wallet_core::internal::ErrorPtr error(statement);                      \
         ASSERT_EQ(nullptr, error);                                             \
+    } while (0)
+
+#define EXPECT_ERROR(statement)                                                \
+    do                                                                         \
+    {                                                                          \
+        wallet_core::internal::ErrorPtr error(statement);                      \
+        EXPECT_NE(nullptr, error);                                             \
     } while (0)
 
 #define E(statement)                                                           \
@@ -74,4 +81,4 @@ inline bool operator!=(const PrivateKey& lhs, const PrivateKey& rhs)
     return !(lhs == rhs);
 }
 
-#endif // UTILITY_H
+#endif // MULTY_TEST_UTILITY_H

--- a/multy_test/value_printers.h
+++ b/multy_test/value_printers.h
@@ -4,8 +4,8 @@
  * See LICENSE for details
  */
 
-#ifndef VALUE_PRINTERS_H
-#define VALUE_PRINTERS_H
+#ifndef MULTY_TEST_VALUE_PRINTERS_H
+#define MULTY_TEST_VALUE_PRINTERS_H
 
 #include "multy_core/account.h"
 
@@ -50,4 +50,4 @@ inline void PrintTo(const std::unique_ptr<T, D>& up, std::ostream* out)
     }
 }
 
-#endif // VALUE_PRINTERS_H
+#endif // MULTY_TEST_VALUE_PRINTERS_H

--- a/multy_transaction/internal/amount.cpp
+++ b/multy_transaction/internal/amount.cpp
@@ -18,10 +18,12 @@ void throw_exception(const std::string& message)
 {
     throw Exception(message);
 }
+const int32_t AMOUNT_MAGIC = __LINE__;
 
 } // namespace
 
 Amount::Amount(const char* value)
+    : m_magic(&AMOUNT_MAGIC)
 {
     throw_if_wally_error(
             mpz_init_set_str(m_value, value, 10),
@@ -29,11 +31,13 @@ Amount::Amount(const char* value)
 }
 
 Amount::Amount(int32_t value)
+    : m_magic(&AMOUNT_MAGIC)
 {
     mpz_init_set_si(m_value, value);
 }
 
 Amount::Amount(const Amount& other)
+    : m_magic(&AMOUNT_MAGIC)
 {
     mpz_init_set(m_value, other.m_value);
 }
@@ -51,6 +55,7 @@ Amount& Amount::operator=(const Amount& other)
 }
 
 Amount::Amount(int64_t value)
+    : m_magic(&AMOUNT_MAGIC)
 {
     mpz_init(m_value);
     mpz_import(m_value, 1, -1, sizeof(value), 0, 0, &value);
@@ -61,6 +66,7 @@ Amount::Amount(int64_t value)
 }
 
 Amount::Amount(uint64_t value)
+    : m_magic(&AMOUNT_MAGIC)
 {
     mpz_init(m_value);
     mpz_import(m_value, 1, -1, sizeof(value), 0, 0, &value);
@@ -161,4 +167,9 @@ bool Amount::operator<=(const Amount& other) const
 bool Amount::operator>=(const Amount& other) const
 {
     return mpz_cmp(m_value, other.m_value) >= 0;
+}
+
+bool Amount::is_valid() const
+{
+    return m_magic == &AMOUNT_MAGIC;
 }

--- a/multy_transaction/internal/amount.h
+++ b/multy_transaction/internal/amount.h
@@ -61,8 +61,11 @@ struct MULTY_TRANSACTION_API Amount
     bool operator<=(const Amount& other) const;
     bool operator>=(const Amount& other) const;
 
+    bool is_valid() const;
+
 private:
     mpz_t m_value;
+    const void* m_magic;
 };
 
 // TODO: Those perform not-so-obvious conversion to Amount, get rid of it.

--- a/multy_transaction/internal/properties.cpp
+++ b/multy_transaction/internal/properties.cpp
@@ -22,6 +22,8 @@ namespace
 using namespace wallet_core::internal;
 typedef Properties::Binder Binder;
 
+const int32_t PROPERTIES_MAGIC = __LINE__;
+
 enum ValueType
 {
     VALUE_TYPE_INT32,
@@ -311,7 +313,8 @@ Properties::Binder::~Binder()
 }
 
 Properties::Properties(const std::string& name)
-    : m_name(name)
+    : m_magic(&PROPERTIES_MAGIC),
+      m_name(name)
 {
 }
 
@@ -521,4 +524,9 @@ bool Properties::is_set(const void* value) const
 void Properties::throw_exception(const std::string& message) const
 {
     throw Exception(get_name() + " : " + message);
+}
+
+bool Properties::is_valid() const
+{
+    return m_magic == &PROPERTIES_MAGIC;
 }

--- a/multy_transaction/internal/properties.h
+++ b/multy_transaction/internal/properties.h
@@ -201,6 +201,7 @@ struct MULTY_TRANSACTION_API Properties
 
     // Not a part of public interface.
     void throw_exception(const std::string& message) const;
+    bool is_valid() const;
 
 private:
     template <typename T, typename P>
@@ -214,6 +215,7 @@ protected:
     BinderPtr& make_property(const std::string& name, const void* value);
 
 private:
+    const void* m_magic;
     const std::string m_name;
     std::map<std::string, BinderPtr> m_properties;
     std::map<const void*, std::string> m_property_name_by_value;
@@ -241,6 +243,26 @@ public:
           m_value(std::move(initial_value))
     {
         props.bind_property(name, &m_value, trait, std::move(predicate));
+    }
+
+    const T& operator*() const
+    {
+        return get_value();
+    }
+
+    T& operator*()
+    {
+        return get_value();
+    }
+
+    const T* operator->() const
+    {
+        return &get_value();
+    }
+
+    T* operator->()
+    {
+        return &get_value();
     }
 
     const T& get_value() const

--- a/multy_transaction/internal/transaction.cpp
+++ b/multy_transaction/internal/transaction.cpp
@@ -6,7 +6,22 @@
 
 #include "transaction.h"
 
+namespace
+{
+const int32_t TRANSACTION_MAGIC = __LINE__;
+} // namespace
+
+Transaction::Transaction()
+    : m_magic(&TRANSACTION_MAGIC)
+{
+
+}
+
 Transaction::~Transaction()
 {
 }
 
+bool Transaction::is_valid() const
+{
+    return m_magic == &TRANSACTION_MAGIC;
+}

--- a/multy_transaction/internal/transaction.h
+++ b/multy_transaction/internal/transaction.h
@@ -23,6 +23,7 @@ struct MULTY_TRANSACTION_API Transaction
 {
     typedef wallet_core::internal::BinaryDataPtr BinaryDataPtr;
 
+    Transaction();
     virtual ~Transaction();
 
     virtual Currency get_currency() const = 0;
@@ -75,6 +76,11 @@ struct MULTY_TRANSACTION_API Transaction
      * @return own properties of the transaction, DO NOT DELETE/FREE.
      */
     virtual Properties& get_transaction_properties() = 0;
+
+    bool is_valid() const;
+
+private:
+    const void* m_magic;
 };
 
 #endif // MULTY_TRANSACTION_INTERNAL_TRANSACTION_H

--- a/multy_transaction/properties.h
+++ b/multy_transaction/properties.h
@@ -20,33 +20,107 @@ struct BinaryData;
 struct PrivateKey;
 struct Properties;
 
+/** Properties system.
+ *
+ * In order to configure varios aspects of objects in library, we've desided to
+ * utilize propery system. Properties object is a collection of name:value pairs.
+ *  * Property is strongly typed and attempt to set value to type other that
+ *    supported would fail.
+ *  * Every property might have additional retrictions on type range and\or
+ *    value, setting a property might fail if those restictions are not met.
+ *  * Setting a property by non-existing key would fail.
+ * In case of failure Error object is non-null and contains detailed
+ * description, it must be disposed with free_error().
+ */
+
+/** Set property int value.
+ *
+ * Sets property value to a copy of given int.
+ * @param properties - non null valid properties object.
+ * @param name - name of the property to reset.
+ * @param value - int to set as value.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_set_int32_value(
         struct Properties* properties, const char* name, int32_t value);
 
+/** Set property string value.
+ *
+ * Sets property value to a copy of given string.
+ * @param properties - non null valid properties object.
+ * @param name - name of the property to reset.
+ * @param value - string to set as value.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_set_string_value(
         struct Properties* properties, const char* name, const char* value);
 
+/** Set property Amount value.
+ *
+ * Sets property value to a copy of given Amount.
+ * @param properties - non null valid properties object.
+ * @param name - name of the property to reset.
+ * @param value - Amount to set as value.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_set_amount_value(
         struct Properties* properties,
         const char* name,
         const struct Amount* value);
 
+/** Set property BinaryData value.
+ *
+ * Sets property value to a copy of given binary data.
+ * @param properties - non null valid properties object.
+ * @param name - name of the property to reset.
+ * @param value - BinaryData to set as value.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_set_binary_data_value(
         struct Properties* properties,
         const char* name,
         const struct BinaryData* value);
 
+/** Set property PrivateKey value.
+ *
+ * Sets property value to a copy of given private key.
+ * @param properties - non null valid properties object.
+ * @param name - name of the property to reset.
+ * @param value - private key to set as value.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_set_private_key_value(
         struct Properties* properties,
         const char* name,
         const struct PrivateKey* value);
 
+
+/** Reset property value by key name.
+ *
+ * Resets given property by name.
+ * @param properties - non null valid properties object.
+ * @param name - name of the property to reset.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_reset_value(
         struct Properties* properties, const char* name);
 
+/** Validate properties instance.
+ *
+ * Checks that all required properties are set.
+ * @param properties - non null valid properties object.
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_validate(
         const struct Properties* properties);
 
+/** Get properties specification string.
+ *
+ * Allows client to introspect all properties keys and expected types.
+ * @param properties - non null valid properties object.
+ * @param out_specification - specification string, must be freed with free_string().
+ * @return null if no error, Error object otherwise.
+ */
 MULTY_TRANSACTION_API struct Error* properties_get_specification(
         const struct Properties* properties, const char** out_specification);
 

--- a/multy_transaction/src/amount.cpp
+++ b/multy_transaction/src/amount.cpp
@@ -21,7 +21,7 @@ Error* make_amount(const char* amount_str, Amount** new_amount)
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
-    OUT_CHECK(*new_amount);
+    OUT_CHECK_OBJECT(*new_amount);
 
     return nullptr;
 }

--- a/multy_transaction/src/properties.cpp
+++ b/multy_transaction/src/properties.cpp
@@ -16,7 +16,7 @@
 Error* properties_set_int32_value(
         Properties* properties, const char* name, int32_t value)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(name);
     try
     {
@@ -30,7 +30,7 @@ Error* properties_set_int32_value(
 Error* properties_set_string_value(
         Properties* properties, const char* name, const char* value)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(name);
     ARG_CHECK(value);
     try
@@ -45,7 +45,7 @@ Error* properties_set_string_value(
 Error* properties_set_amount_value(
         Properties* properties, const char* name, const Amount* value)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(name);
     ARG_CHECK(value);
     try
@@ -60,7 +60,7 @@ Error* properties_set_amount_value(
 Error* properties_set_binary_data_value(
         Properties* properties, const char* name, const BinaryData* value)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(name);
     ARG_CHECK(value);
     try
@@ -75,7 +75,7 @@ Error* properties_set_binary_data_value(
 Error* properties_set_private_key_value(
         Properties* properties, const char* name, const PrivateKey* value)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(name);
     ARG_CHECK(value);
     try
@@ -89,7 +89,7 @@ Error* properties_set_private_key_value(
 
 Error* properties_reset_value(Properties* properties, const char* name)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(name);
     try
     {
@@ -102,7 +102,7 @@ Error* properties_reset_value(Properties* properties, const char* name)
 
 Error* properties_validate(const Properties* properties)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     try
     {
         std::vector<std::string> missing_properies;
@@ -127,7 +127,7 @@ Error* properties_validate(const Properties* properties)
 
 Error* properties_get_specification(const Properties* properties, const char** out_specification)
 {
-    ARG_CHECK(properties);
+    ARG_CHECK_OBJECT(properties);
     ARG_CHECK(out_specification);
     try
     {

--- a/multy_transaction/src/transaction.cpp
+++ b/multy_transaction/src/transaction.cpp
@@ -21,7 +21,7 @@ using namespace multy_transaction::internal;
 
 Error* make_transaction(const Account* account, Transaction** new_transaction)
 {
-    ARG_CHECK(account);
+    ARG_CHECK_OBJECT(account);
     ARG_CHECK(new_transaction);
 
     try
@@ -37,7 +37,7 @@ Error* make_transaction(const Account* account, Transaction** new_transaction)
         }
     }
     CATCH_EXCEPTION_RETURN_ERROR();
-    OUT_CHECK(*new_transaction);
+    OUT_CHECK_OBJECT(*new_transaction);
 
     return nullptr;
 }
@@ -47,7 +47,7 @@ Error* transaction_has_trait(
         TransactionTrait trait,
         bool* out_has_capability)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(trait == TRANSACTION_REQUIRES_EXPLICIT_SOURCE
             || trait == TRANSACTION_SUPPORTS_MULTIPLE_SOURCES
             || trait == TRANSACTION_SUPPORTS_MULTIPLE_DESTINATIONS
@@ -66,7 +66,7 @@ Error* transaction_has_trait(
 Error* transaction_get_currency(
         const Transaction* transaction, Currency* out_currency)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(out_currency);
 
     try
@@ -80,7 +80,7 @@ Error* transaction_get_currency(
 
 Error* transaction_add_source(Transaction* transaction, Properties** source)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(source);
 
     try
@@ -89,7 +89,7 @@ Error* transaction_add_source(Transaction* transaction, Properties** source)
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
-    OUT_CHECK(*source);
+    OUT_CHECK_OBJECT(*source);
 
     return nullptr;
 }
@@ -97,7 +97,7 @@ Error* transaction_add_source(Transaction* transaction, Properties** source)
 Error* transaction_add_destination(
         Transaction* transaction, Properties** destination)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(destination);
 
     try
@@ -106,14 +106,14 @@ Error* transaction_add_destination(
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
-    OUT_CHECK(*destination);
+    OUT_CHECK_OBJECT(*destination);
 
     return nullptr;
 }
 
 Error* transaction_get_fee(Transaction* transaction, Properties** fee)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(fee);
 
     try
@@ -122,41 +122,47 @@ Error* transaction_get_fee(Transaction* transaction, Properties** fee)
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
-    OUT_CHECK(*fee);
+    OUT_CHECK_OBJECT(*fee);
 
     return nullptr;
 }
-Error* transaction_estimate_fee(Transaction* transaction, Amount* out_fee_estimate)
+Error* transaction_estimate_fee(Transaction* transaction, Amount** out_fee_estimate)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(out_fee_estimate);
 
     try
     {
-        *out_fee_estimate = transaction->estimate_fee();
+        AmountPtr result(new Amount);
+        *result = transaction->estimate_fee();
+        *out_fee_estimate = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR();
+    OUT_CHECK_OBJECT(*out_fee_estimate);
 
     return nullptr;
 }
 
-Error* transaction_get_total_fee(Transaction* transaction, Amount* out_total_fee)
+Error* transaction_get_total_fee(Transaction* transaction, Amount** out_total_fee)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(out_total_fee);
 
     try
     {
-        *out_total_fee = transaction->get_total_fee();
+        AmountPtr result(new Amount);
+        *result = transaction->get_total_fee();
+        *out_total_fee = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR();
+    OUT_CHECK_OBJECT(*out_total_fee);
 
     return nullptr;
 }
 
 Error* transaction_update(Transaction* transaction)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
 
     try
     {
@@ -169,7 +175,7 @@ Error* transaction_update(Transaction* transaction)
 
 Error* transaction_sign(Transaction* transaction)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
 
     try
     {
@@ -182,9 +188,9 @@ Error* transaction_sign(Transaction* transaction)
 
 Error* transaction_serialize(
         const Transaction* transaction,
-        BinaryData** const out_serialized_transaction)
+        BinaryData** out_serialized_transaction)
 {
-    ARG_CHECK(transaction);
+    ARG_CHECK_OBJECT(transaction);
     ARG_CHECK(out_serialized_transaction);
 
     try

--- a/multy_transaction/transaction.h
+++ b/multy_transaction/transaction.h
@@ -59,16 +59,10 @@ MULTY_TRANSACTION_API struct Error* transaction_get_fee(
  * Please note that final fee value might differ from this estimation.
  */
 MULTY_TRANSACTION_API struct Error* transaction_estimate_fee(
-        struct Transaction* transaction, struct Amount* out_fee_estimation);
+        struct Transaction* transaction, struct Amount** out_fee_estimation);
 
 MULTY_TRANSACTION_API struct Error* transaction_get_total_fee(
-        struct Transaction* transaction, struct Amount* out_fee_total);
-
-///** Get total amount transferred from sources to destinations.
-// * @return
-// */
-//MULTY_TRANSACTION_API struct Error* transaction_get_total(
-//        struct Transaction* transaction, struct Amount* out_total);
+        struct Transaction* transaction, struct Amount** out_fee_total);
 
 /** Validate and update transaction internal state.
  *
@@ -87,14 +81,6 @@ MULTY_TRANSACTION_API struct Error* transaction_sign(
 MULTY_TRANSACTION_API struct Error* transaction_serialize(
         const struct Transaction* transaction,
         struct BinaryData** out_serialized_transaction);
-
-// MULTY_TRANSACTION_API struct Error* transaction_serialize_raw(
-//        const struct Transaction* transaction,
-//        const struct BinaryData** out_raw_transaction);
-
-//MULTY_TRANSACTION_API struct Error* transaction_get_hash(
-//        const struct Transaction* transaction,
-//        const struct BinaryData** out_transaction_hash);
 
 MULTY_TRANSACTION_API void free_transaction(struct Transaction* transaction);
 


### PR DESCRIPTION
Added more checks to avoid crashes by dereferencing null-pointers.
Added tests for:
 * make_binary_data_from_hex
 * make_binary_data_from_bytes;

Added extra object validity checks for:
 * Account;
 * Ammount;
 * HDAccount;
 * Key;
 * ExtendedKey;
 * Properties;
 * Transaction.

Functions to retrieve library version;

API update: Avoid creating Amount on stack in clients code;