### PR TITLE
MUL-643: BTC explicit Change address

### DIFF
--- a/multy_core/src/api/big_int_impl.h
+++ b/multy_core/src/api/big_int_impl.h
@@ -50,6 +50,9 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     // Returns value as uint64_t, throws exception if value is too big.
     uint64_t get_value_as_uint64() const;
 
+    template <typename T>
+    T get() const;
+
     size_t get_exported_size_in_bytes() const;
 
     typedef multy_core::internal::BinaryDataPtr BinaryDataPtr;
@@ -90,6 +93,24 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
 private:
     mpz_t m_value;
 };
+
+template <>
+inline uint64_t BigInt::get<uint64_t>() const
+{
+    return get_value_as_uint64();
+}
+
+template <>
+inline int64_t BigInt::get<int64_t>() const
+{
+    return get_value_as_int64();
+}
+
+template <>
+inline std::string BigInt::get<std::string>() const
+{
+    return get_value();
+}
 
 // TODO: Those perform not-so-obvious conversion to BigInt, get rid of it.
 #define MULTY_BIG_INT_DEFINE_OP(op)                                                   \

--- a/multy_core/src/api/properties.cpp
+++ b/multy_core/src/api/properties.cpp
@@ -19,7 +19,7 @@ Error* properties_set_int32_value(
     ARG_CHECK(name);
     try
     {
-        properties->set_property(name, value);
+        properties->set_property_value(name, value);
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
@@ -34,7 +34,7 @@ Error* properties_set_string_value(
     ARG_CHECK(value);
     try
     {
-        properties->set_property(name, value);
+        properties->set_property_value(name, value);
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
@@ -49,7 +49,7 @@ Error* properties_set_big_int_value(
     ARG_CHECK(value);
     try
     {
-        properties->set_property(name, *value);
+        properties->set_property_value(name, *value);
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
@@ -64,7 +64,7 @@ Error* properties_set_binary_data_value(
     ARG_CHECK(value);
     try
     {
-        properties->set_property(name, *value);
+        properties->set_property_value(name, *value);
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 
@@ -79,7 +79,7 @@ Error* properties_set_private_key_value(
     ARG_CHECK(value);
     try
     {
-        properties->set_property(name, *value);
+        properties->set_property_value(name, *value);
     }
     CATCH_EXCEPTION_RETURN_ERROR();
 

--- a/multy_core/src/ethereum/ethereum_transaction.cpp
+++ b/multy_core/src/ethereum/ethereum_transaction.cpp
@@ -37,7 +37,7 @@ const uint8_t RLP_DATA_IND_LEN_ZERO = RLP_DATA_IMM_LEN_START + RLP_DATA_IMM_LEN_
 const uint8_t RLP_LIST_IMM_LEN_COUNT = 256 - RLP_LIST_START - RLP_MAX_LENGTH_BYTES;
 const uint8_t RLP_LIST_IND_LEN_ZERO = RLP_LIST_START + RLP_LIST_IMM_LEN_COUNT - 1;
 
-const int PRE_EIP155_CHAIN_ID = -4;
+const int32_t PRE_EIP155_CHAIN_ID = -4;
 
 #define LV(x) (#x " : ") << std::hex << static_cast<int>(x)
 

--- a/multy_test/CMakeLists.txt
+++ b/multy_test/CMakeLists.txt
@@ -1,3 +1,11 @@
+
+if (MULTY_MORE_WARNINGS)
+    # Set of warnings is maller than for multy_core to make life easier.
+    add_definitions(
+        -Wall -Wunused -Wfloat-equal -Wwrite-strings
+    )
+endif()
+
 # Explicitly building multy_test as shared library, otherwise test cases would be thrown away by
 # linker as symbols with internal linkage with is never referenced.
 # That means that test cases can't be discovered by gtest runtime and hence not run.

--- a/multy_test/test_ethereum_transaction.cpp
+++ b/multy_test/test_ethereum_transaction.cpp
@@ -118,26 +118,26 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet1)
 
     {
         Properties& properties = transaction->get_transaction_properties();
-        properties.set_property("nonce", BigInt("0"));
-        properties.set_property("chain_id", ETHEREUM_CHAIN_ID_RINKEBY);
+        properties.set_property_value("nonce", BigInt("0"));
+        properties.set_property_value("chain_id", ETHEREUM_CHAIN_ID_RINKEBY);
     }
 
     {
         Properties& source = transaction->add_source();
-        source.set_property("amount", balance);
+        source.set_property_value("amount", balance);
     }
 
     {
         const bytes address = from_hex("d1b48a11e2251555c3c6d8b93e13f9aa2f51ea19");
         Properties& destination = transaction->add_destination();
-        destination.set_property("address", to_binary_data(address));
-        destination.set_property("amount", value);
+        destination.set_property_value("address", to_binary_data(address));
+        destination.set_property_value("amount", value);
     }
 
     {
         Properties& fee = transaction->get_fee();
-        fee.set_property("gas_price", gas_price);
-        fee.set_property("gas_limit", gas_limit);
+        fee.set_property_value("gas_price", gas_price);
+        fee.set_property_value("gas_limit", gas_limit);
     }
     BinaryDataPtr serialied = transaction->serialize();  
     ASSERT_EQ(to_binary_data(from_hex(
@@ -166,26 +166,26 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet2)
 
     {
         Properties& properties = transaction->get_transaction_properties();
-        properties.set_property("nonce", BigInt("4"));
-        properties.set_property("chain_id", ETHEREUM_CHAIN_ID_RINKEBY);
+        properties.set_property_value("nonce", BigInt("4"));
+        properties.set_property_value("chain_id", ETHEREUM_CHAIN_ID_RINKEBY);
     }
 
     {
         Properties& source = transaction->add_source();
-        source.set_property("amount", balance);
+        source.set_property_value("amount", balance);
     }
 
     {
         const bytes address = from_hex("d1b48a11e2251555c3c6d8b93e13f9aa2f51ea19");
         Properties& destination = transaction->add_destination();
-        destination.set_property("address", to_binary_data(address));
-        destination.set_property("amount", value);
+        destination.set_property_value("address", to_binary_data(address));
+        destination.set_property_value("amount", value);
     }
 
     {
         Properties& fee = transaction->get_fee();
-        fee.set_property("gas_price", gas_price);
-        fee.set_property("gas_limit", gas_limit);
+        fee.set_property_value("gas_price", gas_price);
+        fee.set_property_value("gas_limit", gas_limit);
     }
 
     BigInt estimated_fee = transaction->estimate_total_fee(1, 1);
@@ -222,27 +222,27 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet_withdata)
     {
         const bytes payload = from_hex("ffff");
         Properties& properties = transaction->get_transaction_properties();
-        properties.set_property("nonce", BigInt("3"));
-        properties.set_property("chain_id", ETHEREUM_CHAIN_ID_RINKEBY);
-        properties.set_property("payload", to_binary_data(payload));
+        properties.set_property_value("nonce", BigInt("3"));
+        properties.set_property_value("chain_id", ETHEREUM_CHAIN_ID_RINKEBY);
+        properties.set_property_value("payload", to_binary_data(payload));
     }
 
     {
         Properties& source = transaction->add_source();
-        source.set_property("amount", balance);
+        source.set_property_value("amount", balance);
     }
 
     {
         const bytes address = from_hex("d1b48a11e2251555c3c6d8b93e13f9aa2f51ea19");
         Properties& destination = transaction->add_destination();
-        destination.set_property("address", to_binary_data(address));
-        destination.set_property("amount", value);
+        destination.set_property_value("address", to_binary_data(address));
+        destination.set_property_value("amount", value);
     }
 
     {
         Properties& fee = transaction->get_fee();
-        fee.set_property("gas_price", gas_price);
-        fee.set_property("gas_limit", gas_limit);
+        fee.set_property_value("gas_price", gas_price);
+        fee.set_property_value("gas_limit", gas_limit);
     }
 
     BigInt estimated_fee = transaction->estimate_total_fee(1, 1);

--- a/multy_test/value_printers.h
+++ b/multy_test/value_printers.h
@@ -37,6 +37,12 @@ void PrintTo(const AddressType& e, std::ostream* out);
 void PrintTo(const Transaction& e, std::ostream* out);
 void PrintTo(const BigInt& a, std::ostream* out);
 
+inline std::ostream& operator<<(std::ostream& out, const BigInt& value)
+{
+    PrintTo(value, &out);
+    return out;
+}
+
 template <typename T, typename D>
 inline void PrintTo(const std::unique_ptr<T, D>& up, std::ostream* out)
 {


### PR DESCRIPTION
Added a property 'is_change' to a destinaion, setting which does folowing:
 * sets amount property as read-only;
 * marks that destination as change destination (there could be only one);
 * adds all excess value to the change destination to make fee exactly what user requested.

Added tests to verify change address value;

Minor Properties refactoring:
 * Added Properties::get_property_value()
 * Added Property::READONLY, attempt to set value for readonly property would fail at runtime;
 * Property can now change it's Traits at run-time;
 * Renamed Properties::set_property() into Properties::set_property_value()
 * tests to verify more PropertyT and Properties stuff;