### PR TITLE
MUL-819: Fix warnings in multy_test.

### DIFF
--- a/multy_core/CMakeLists.txt
+++ b/multy_core/CMakeLists.txt
@@ -4,6 +4,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (MULTY_MORE_WARNINGS)
     add_definitions(
         -Wall -Weffc++ -Wpedantic -Wextra -Wunused -Wfloat-equal -Wpointer-arith -Wwrite-strings
+
+        # Disabled warnings:
+         -Wno-missing-braces # false-positive on std::array initialization.
     )
 endif()
 

--- a/multy_test/CMakeLists.txt
+++ b/multy_test/CMakeLists.txt
@@ -1,8 +1,11 @@
 
 if (MULTY_MORE_WARNINGS)
-    # Set of warnings is maller than for multy_core to make life easier.
+    # Set of warnings is smaller than for multy_core to make life easier.
     add_definitions(
         -Wall -Wunused -Wfloat-equal -Wwrite-strings
+
+        # Disabled warnings:
+        -Wno-missing-braces # false-positive on std::array initialization.
     )
 endif()
 

--- a/multy_test/test_account.cpp
+++ b/multy_test/test_account.cpp
@@ -28,11 +28,8 @@ using namespace test_utility;
 const char* TEST_ADDRESS = "TEST_ADDRESS";
 const HDPath TEST_PATH = {1, 2, 3};
 const char* TEST_PATH_STRING = "m/1/2/3";
-const Currency TEST_CURRENCY = CURRENCY_BITCOIN;
 
-const uint32_t INVALID_INDEX = HARDENED_INDEX_BASE + 1;
 const Currency INVALID_CURRENCY = static_cast<Currency>(-1);
-const AddressType INVALID_ADDRESS = static_cast<AddressType>(-1);
 
 struct TestPublicKey : public PublicKey
 {

--- a/multy_test/test_keys.cpp
+++ b/multy_test/test_keys.cpp
@@ -81,7 +81,6 @@ GTEST_TEST(KeysTestInvalidArgs, make_master_key)
 
 GTEST_TEST(KeysTestInvalidArgs, make_child_key)
 {
-    const KeyType INVALID_KEY_TYPE = static_cast<KeyType>(-1);
     const ExtendedKey parent_key = make_dummy_extended_key();
 
     ErrorPtr error;

--- a/multy_test/test_transaction.cpp
+++ b/multy_test/test_transaction.cpp
@@ -26,7 +26,7 @@ using namespace multy_core::internal;
 
 struct TestTransaction: Transaction
 {
-    TestTransaction(): m_properties(""), m_total("5"){}
+    TestTransaction(): m_total("5"), m_properties("") {}
     Currency get_currency() const override
     {
         return m_currency;
@@ -44,12 +44,12 @@ struct TestTransaction: Transaction
 
     BigInt estimate_total_fee(size_t sources_count, size_t destinations_count) const override
     {
-        return (m_total-1);
+        return (m_total - 1);
     }
 
     BigInt get_total_fee() const override
     {
-        return (m_total-2);
+        return (m_total - 2);
     }
 
     Properties& add_source() override
@@ -66,7 +66,6 @@ struct TestTransaction: Transaction
     {
         return m_properties;
     }
-
 
     Properties& get_transaction_properties() override
     {

--- a/multy_test/value_printers.cpp
+++ b/multy_test/value_printers.cpp
@@ -81,8 +81,7 @@ void PrintTo(const Error& e, std::ostream* out)
 
 void PrintTo(const BinaryData& data, std::ostream* out)
 {
-    *out << "BinaryData{ " << (data.data ? to_hex(data) : std::string("<null>"))
-         << ", " << data.len << " }";
+    *out << "BinaryData{ " << data << " }";
 }
 
 void PrintTo(const Key& key, std::ostream* out)


### PR DESCRIPTION
Removed unused variables;
Re-using operator<< for BinaryData;
Added -Wno-missing-braces to suppress false-positive on std::array initialization.