### PR TITLE
MUL-890: BTC transaction minimum fee set to 2 Satoshi per byte

### DIFF
--- a/multy_core/src/bitcoin/bitcoin_transaction.cpp
+++ b/multy_core/src/bitcoin/bitcoin_transaction.cpp
@@ -373,7 +373,12 @@ public:
                   properties,
                   "amount_per_byte",
                   Property::OPTIONAL,
-                  verify_non_negative_amount),
+                  [this](const BigInt& amount) {
+                      if (amount < BigInt(2))
+                      {
+                          THROW_EXCEPTION("Value should be> 2.");
+                      }
+                  }),
           min_amount_per_byte(
                   properties, "min_amount_per_byte", Property::OPTIONAL)
     {


### PR DESCRIPTION
Add check min value to set "amount_per_byte" in destination properties is 2 satoshi
@Enmk 