### PR TITLE
MUL-930: FIX BTC Transaction address verification

### DIFF
--- a/multy_core/src/bitcoin/bitcoin_account.cpp
+++ b/multy_core/src/bitcoin/bitcoin_account.cpp
@@ -316,10 +316,7 @@ BinaryDataPtr parse_bitcoin_address(const char* address,
                                     BitcoinAddressType* address_type)
 {
     BinaryDataPtr out_binary_data;
-    size_t binary_size = 0;
-    THROW_IF_WALLY_ERROR(
-                wally_base58_get_length(address, &binary_size),
-                "Can not get the len");
+    size_t binary_size = strlen(address);
     std::vector<uint8_t> decoded(binary_size, 0);
 
     THROW_IF_WALLY_ERROR(

--- a/multy_test/test_bitcoin_transaction.cpp
+++ b/multy_test/test_bitcoin_transaction.cpp
@@ -819,3 +819,22 @@ GTEST_TEST(BitcoinTransactionTest, transaction_update)
     );
 }
 
+GTEST_TEST(BitcoinTransactionTest, destination_address_verification)
+{
+    const AccountPtr account = make_account(CURRENCY_BITCOIN, "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7");
+
+    TransactionPtr transaction;
+    make_transaction(account.get(), reset_sp(transaction));
+    {
+        Properties* destination = nullptr;
+        HANDLE_ERROR(transaction_add_destination(transaction.get(), &destination));
+
+        EXPECT_ERROR(properties_set_string_value(destination, "address", ""));
+        EXPECT_ERROR(properties_set_string_value(destination, "address", " "));
+        EXPECT_ERROR(properties_set_string_value(destination, "address", "123"));
+        // valid address mzqiDnETWkunRDZxjUQ34JzN1LDevh5DpU
+        EXPECT_ERROR(properties_set_string_value(destination, "address", "mzqiDnETWkunRDZxjUQ34JzN1LDevh5D"));
+
+        HANDLE_ERROR(properties_set_string_value(destination, "address", "mzqiDnETWkunRDZxjUQ34JzN1LDevh5DpU"));
+    }
+}


### PR DESCRIPTION
Force BTC Transaction to verify destination address immediately, not just when transaction is serialized.