### PR TITLE
MUL-1006: Disable death-tests that crash android client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
+message("CMAKE_CURRENT_BINARY_DIR  : ${CMAKE_CURRENT_BINARY_DIR}")
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -13,17 +15,27 @@ option(MULTY_ENABLE_SIMULATE_ERROR "Enable simulating errors in multy_core, see 
 option(BUILD_SHARED_LIBS "Build as shared libraries." OFF)
 option(MULTY_WITH_TEST_APP "Build sample app that runs the tests (consider MULTY_WITH_TESTS)." OFF)
 
+project(multy C CXX)
+
 # Platform-specific options
 if (ANDROID)
+    message("Multy Android flavour.")
+    add_definitions(-DMULTY_BUILD_FOR_ANDROID=1)
+
     # Android specific options, must be prefixed with MULTY_ANDROID_
     set(MULTY_ANDROID_PATH_TO_JNI_WRAPPER "" CACHE PATH "Path to jni wrapper source file.")
-elseif(DEFINED IOS_PLATFORM)
-    # iOS specific options, must be prefixed with MULTY_IOS_
-else()
-    # Desktop specific options, must be prefixed with MULTY_DESKTOP_
-endif()
 
-project(multy C CXX)
+elseif(DEFINED IOS_PLATFORM)
+    message("Multy iOS flavour.")
+    add_definitions(-DMULTY_BUILD_FOR_IOS=1)
+    # iOS specific options, must be prefixed with MULTY_IOS_
+
+else()
+    message("Multy Desktop flavour.")
+    add_definitions(-DMULTY_BUILD_FOR_DESKTOP=1)
+    # Desktop specific options, must be prefixed with MULTY_DESKTOP_
+
+endif()
 
 if(MULTY_WITH_TEST_APP)
     set(MULTY_WITH_TESTS ON)

--- a/multy_test/test_deletion.cpp
+++ b/multy_test/test_deletion.cpp
@@ -22,6 +22,17 @@ namespace
 using namespace multy_core::internal;
 } // namespace
 
+// Disable death-test on non-Desktop platforms, since those might crash on mobile.
+#if defined(MULTY_BUILD_FOR_DESKTOP) && MULTY_BUILD_FOR_DESKTOP
+    #define MULTY_ASSERT_DEATH_IF_SUPPORTED(statement, message) \
+            ASSERT_DEATH_IF_SUPPORTED(statement, message)
+    #define MULTY_EXPECT_DEATH_IF_SUPPORTED(statement, message) \
+            EXPECT_DEATH_IF_SUPPORTED(statement, message)
+#else
+    #define MULTY_ASSERT_DEATH_IF_SUPPORTED(statement, message)
+    #define MULTY_EXPECT_DEATH_IF_SUPPORTED(statement, message)
+#endif
+
 class DeletionTestP : public ::testing::TestWithParam<BlockchainType>
 {
 public:
@@ -76,7 +87,7 @@ TEST_P(DeletionTestP, free_hd_account)
     ASSERT_FALSE(hd_account_ptr->is_valid());
 
     // Ensuring that double-free is not performed.
-    ASSERT_DEATH_IF_SUPPORTED(free_hd_account(hd_account_ptr),
+    MULTY_ASSERT_DEATH_IF_SUPPORTED(free_hd_account(hd_account_ptr),
             "trying to free invalid object");
 }
 
@@ -89,7 +100,7 @@ TEST_P(DeletionTestP, free_account)
     ASSERT_FALSE(account_ptr->is_valid());
 
     // Ensuring that double-free is not performed.
-    ASSERT_DEATH_IF_SUPPORTED(free_account(account_ptr),
+    MULTY_ASSERT_DEATH_IF_SUPPORTED(free_account(account_ptr),
             "trying to free invalid object");
 }
 
@@ -107,7 +118,7 @@ TEST_P(DeletionTestP, free_private_key)
     ASSERT_FALSE(key_ptr->is_valid());
 
     // Ensuring that double-free is not performed.
-    ASSERT_DEATH_IF_SUPPORTED(free_key(key_ptr),
+    MULTY_ASSERT_DEATH_IF_SUPPORTED(free_key(key_ptr),
             "trying to free invalid object");
 }
 
@@ -125,7 +136,7 @@ TEST_P(DeletionTestP, free_public_key)
     ASSERT_FALSE(key_ptr->is_valid());
 
     // Ensuring that double-free is not performed.
-    ASSERT_DEATH_IF_SUPPORTED(free_key(key_ptr),
+    MULTY_ASSERT_DEATH_IF_SUPPORTED(free_key(key_ptr),
             "trying to free invalid object");
 }
 
@@ -141,7 +152,7 @@ TEST_P(DeletionTestP, free_transaction)
     ASSERT_FALSE(transaction_ptr->is_valid());
 
     // Ensuring that double-free is not performed.
-    ASSERT_DEATH_IF_SUPPORTED(free_transaction(transaction_ptr),
+    MULTY_ASSERT_DEATH_IF_SUPPORTED(free_transaction(transaction_ptr),
             "trying to free invalid object");
 }
 
@@ -157,6 +168,6 @@ GTEST_TEST(DeletionTest, free_big_int)
     ASSERT_FALSE(big_int_ptr->is_valid());
 
     // Ensuring that double-free is not performed.
-    ASSERT_DEATH_IF_SUPPORTED(free_big_int(big_int_ptr),
+    MULTY_ASSERT_DEATH_IF_SUPPORTED(free_big_int(big_int_ptr),
             "trying to free invalid object");
 }


### PR DESCRIPTION
Disabled death-tests for Android builds only;
Updated Android detection and sample app.