### PR TITLE
MUL-722: BTC add a transaction message

### DIFF
--- a/multy_core/src/api/transaction.cpp
+++ b/multy_core/src/api/transaction.cpp
@@ -129,6 +129,20 @@ Error* transaction_get_fee(Transaction* transaction, Properties** fee)
 
     return nullptr;
 }
+Error* transaction_set_message(Transaction* transaction, const BinaryData* message)
+{
+    ARG_CHECK_OBJECT(transaction);
+    ARG_CHECK(message);
+    ARG_CHECK(message->data && message->len);
+
+    try
+    {
+        transaction->set_message(*message);
+    }
+    CATCH_EXCEPTION_RETURN_ERROR();
+
+    return nullptr;
+}
 
 Error* transaction_get_properties(Transaction* transaction,
         Properties** transaction_properties)

--- a/multy_core/src/api/transaction_impl.h
+++ b/multy_core/src/api/transaction_impl.h
@@ -78,6 +78,7 @@ struct MULTY_CORE_API Transaction : public ::multy_core::internal::ObjectBase<Tr
      */
     virtual Properties& get_transaction_properties() = 0;
 
+    virtual void set_message(const BinaryData& value) = 0;
     static const void* get_object_magic();
 };
 

--- a/multy_core/src/bitcoin/bitcoin_transaction.h
+++ b/multy_core/src/bitcoin/bitcoin_transaction.h
@@ -47,6 +47,7 @@ public:
     Properties& add_source() override;
     Properties& add_destination() override;
     Properties& get_fee() override;
+    void set_message(const BinaryData& value) override;
 
 private:
     uint64_t get_transaction_serialized_size(DestinationsToUse destinations_to_use);
@@ -72,6 +73,7 @@ private:
     BitcoinTransactionFeePtr m_fee;
     std::vector<BitcoinTransactionSourcePtr> m_sources;
     std::vector<BitcoinTransactionDestinationPtr> m_destinations;
+    BitcoinTransactionDestinationPtr m_message;
 };
 
 } // namespace internal

--- a/multy_core/src/ethereum/ethereum_transaction.cpp
+++ b/multy_core/src/ethereum/ethereum_transaction.cpp
@@ -543,5 +543,9 @@ Properties& EthereumTransaction::get_fee()
     return m_fee->get_properties();
 }
 
+void EthereumTransaction::set_message(const BinaryData& value)
+{
+    THROW_EXCEPTION("Not supported yet.");
+}
 } // namespace internal
 } // namespace multy_core

--- a/multy_core/src/ethereum/ethereum_transaction.h
+++ b/multy_core/src/ethereum/ethereum_transaction.h
@@ -54,6 +54,7 @@ public:
     Properties& add_source() override;
     Properties& add_destination() override;
     Properties& get_fee() override;
+    void set_message(const BinaryData& value) override;
 
 private:
     enum SerializationMode

--- a/multy_core/transaction.h
+++ b/multy_core/transaction.h
@@ -52,6 +52,11 @@ MULTY_CORE_API struct Error* transaction_add_destination(
 MULTY_CORE_API struct Error* transaction_get_fee(
         struct Transaction* transaction, struct Properties** fee);
 
+/// @param message - message which user wants to set.
+MULTY_CORE_API struct Error* transaction_set_message(
+        struct Transaction* transaction,
+        const struct BinaryData* message);
+
 /// @param transaction_properties - transaction-level properties, must NOT be freed by the caller.
 MULTY_CORE_API struct Error* transaction_get_properties(
         struct Transaction* transaction, struct Properties** transaction_properties);

--- a/multy_test/mocks.cpp
+++ b/multy_test/mocks.cpp
@@ -177,3 +177,7 @@ Properties& TestTransaction::get_transaction_properties()
 {
     return m_properties;
 }
+
+void TestTransaction::set_message(const BinaryData& value)
+{
+}

--- a/multy_test/mocks.h
+++ b/multy_test/mocks.h
@@ -103,6 +103,7 @@ struct TestTransaction : public Transaction
     Properties& add_destination() override;
     Properties& get_fee() override;
     Properties& get_transaction_properties() override;
+    void set_message(const BinaryData& value) override;
 
 private:
     const BlockchainType m_blockchain = BlockchainType{BLOCKCHAIN_BITCOIN, BLOCKCHAIN_NET_TYPE_MAINNET};

--- a/multy_test/test_transaction.cpp
+++ b/multy_test/test_transaction.cpp
@@ -136,6 +136,17 @@ GTEST_TEST(TransactionTestInvalidArgs, transaction_serialize)
     EXPECT_ERROR(transaction_serialize(&transaction, nullptr));
 }
 
+GTEST_TEST(TransactionTestInvalidArgs, transaction_set_message)
+{
+    TestTransaction transaction;
+    const BinaryData message = as_binary_data("\x04\x02");
+
+    EXPECT_ERROR(
+            transaction_set_message(nullptr, &message));
+    EXPECT_ERROR(
+            transaction_set_message(&transaction, nullptr));
+}
+
 GTEST_TEST(TransactionTestInvalidArgs, transaction_update)
 {
     EXPECT_ERROR(transaction_update(nullptr));
@@ -235,3 +246,13 @@ GTEST_TEST(TransactionTest, transaction_serialize)
     HANDLE_ERROR(
             transaction_serialize(&transaction, reset_sp(serialize_binary_data)));
 }
+
+GTEST_TEST(TransactionTest, transaction_set_message)
+{
+    TestTransaction transaction;
+    const BinaryData message = as_binary_data("\x04\x02");
+
+    HANDLE_ERROR(
+            transaction_set_message(&transaction, &message));
+}
+


### PR DESCRIPTION
Implement API to set a TX message, that would go into serialized transaction and will stay on blockchain.