### PR TITLE
MUL-1204: updated User ID from master key generation

### DIFF
--- a/multy_core/common.h
+++ b/multy_core/common.h
@@ -34,6 +34,7 @@ struct Version
     size_t major;
     size_t minor;
     size_t build;
+
     const char* note;  /// can be null, MUST NOT be freed by caller.
     const char* commit; /// can be null, MUST NOT be freed by caller.
 };

--- a/multy_core/key.h
+++ b/multy_core/key.h
@@ -26,9 +26,18 @@ struct BinaryData;
 MULTY_CORE_API struct Error* make_master_key(
         const struct BinaryData* seed, struct ExtendedKey** new_master_key);
 
-MULTY_CORE_API struct Error* make_key_id(
-        const struct ExtendedKey* key,
-        const char** out_key_id);
+/** Make a user id string from master key.
+ *
+ * User id is a string that uniquely identifies user without giving away
+ * any details about master key.
+ * @param master_key - key that was created from binary seed.
+ * @param out_user_id - resulting user id string, MUST BE freed with free_string().
+ * @return Error if master_key is not a root of the HD key tree or something
+ *          else gone wrong, null otherwise.
+ */
+MULTY_CORE_API struct Error* make_user_id_from_master_key(
+        const struct ExtendedKey* master_key,
+        const char** out_user_id);
 
 /** Make child key from parent key, see BIP32 for key derivation and HD
  * accounts.
@@ -79,10 +88,10 @@ MULTY_CORE_API struct Error* decrypt_with_key(
 */
 
 /** Frees ExtendedKey instance, can take nullptr. **/
-MULTY_CORE_API void free_extended_key(struct ExtendedKey* root);
+MULTY_CORE_API void free_extended_key(struct ExtendedKey* key);
 
 /** Frees struct Key* instance, can take nullptr. **/
-MULTY_CORE_API void free_key(struct Key* root);
+MULTY_CORE_API void free_key(struct Key* key);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/multy_core/src/account_base.cpp
+++ b/multy_core/src/account_base.cpp
@@ -13,10 +13,6 @@
 namespace
 {
 using namespace multy_core::internal;
-constexpr uint32_t hardened_index(uint32_t index)
-{
-    return index | HARDENED_INDEX_BASE;
-}
 
 // According to bip 44, complete address path looks like:
 // m / purpose' / coin_type' / account' / change / address_index

--- a/multy_core/src/api/key_impl.h
+++ b/multy_core/src/api/key_impl.h
@@ -19,6 +19,17 @@ struct BinaryData;
 struct PrivateKey;
 struct PublicKey;
 
+const unsigned char MULTY_USER_ID_VERSION = 0;
+const uint32_t HARDENED_INDEX_BASE = 0x80000000;
+inline constexpr uint32_t hardened_index(uint32_t index)
+{
+    return index | HARDENED_INDEX_BASE;
+}
+
+// 0x4d554c5459 is hex-encoded MULTY, but it doesn't fit into 32 bits,
+// hence trimming the last byte.
+const uint32_t MULTY_USER_ID_PURPOSE = hardened_index(0x4d554c54);
+
 struct MULTY_CORE_API ExtendedKey : public ::multy_core::internal::ObjectBase<ExtendedKey>
 {
     ExtendedKey();
@@ -61,5 +72,28 @@ struct MULTY_CORE_API PublicKey : public Key
     virtual multy_core::internal::PublicKeyPtr clone() const = 0;
     virtual const BinaryData get_content() const = 0;
 };
+
+namespace multy_core
+{
+namespace internal
+{
+
+ExtendedKeyPtr make_master_key(const BinaryData& seed);
+
+ExtendedKeyPtr make_child_key(const ExtendedKey& parent_key,
+        uint32_t chain_code);
+
+/** Makes a user id string from master key.
+ *
+ * User id is a string that uniquely identifies user without giving away
+ * any details about master key.
+ * @param master_key - key that was created from binary seed.
+ * @throws Exception if master_key is not a root of the HD key tree or
+ *          something else gone wrong.
+ */
+CharPtr make_user_id_from_master_key(const ExtendedKey& master_key);
+
+} // namespace internal
+} // namespace multy_core
 
 #endif // MULTY_CORE_INTERNAL_KEY_IMPL_H

--- a/multy_core/src/hd_path.h
+++ b/multy_core/src/hd_path.h
@@ -20,8 +20,6 @@ namespace internal
 // TODO: create a class for HDPath with proper methods.
 typedef std::vector<uint32_t> HDPath;
 
-const uint32_t HARDENED_INDEX_BASE = 0x80000000;
-
 void append_child(uint32_t child_chain_code, HDPath* parent_path);
 
 HDPath make_child_path(HDPath parent_path, uint32_t child_chain_code);

--- a/multy_test/smoke_test.cpp
+++ b/multy_test/smoke_test.cpp
@@ -55,7 +55,7 @@ TEST_P(AccountSmokeTestP, AccountFromEntropy)
     ASSERT_NE(nullptr, root_key);
 
     ConstCharPtr root_id;
-    HANDLE_ERROR(make_key_id(root_key.get(), reset_sp(root_id)));
+    HANDLE_ERROR(make_user_id_from_master_key(root_key.get(), reset_sp(root_id)));
     ASSERT_NE(nullptr, root_id);
     ASSERT_STRCASENE("", root_id.get());
 


### PR DESCRIPTION
Renamed make_key_id() into make_user_id_from_master_key();
Added checks to prevent generating user id from non-root key;
Moved key-related code from src/api/key.cpp to src/api/key_impl.cpp;
Updated test cases to use new function;
Added new test case that validates argument handling of make_user_id_from_master_ke() and checks non-root key detection.