### PR TITLE
MUL-1259 Fixed static analyzer warnings

### DIFF
--- a/multy_core/src/bitcoin/bitcoin_account.cpp
+++ b/multy_core/src/bitcoin/bitcoin_account.cpp
@@ -98,7 +98,7 @@ struct BitcoinPublicKey : public PublicKey
 public:
     typedef std::vector<uint8_t> KeyData;
 
-    BitcoinPublicKey(KeyData key_data)
+    explicit BitcoinPublicKey(KeyData key_data)
         : m_data(std::move(key_data))
     {
     }

--- a/multy_core/src/error_utility.cpp
+++ b/multy_core/src/error_utility.cpp
@@ -26,12 +26,12 @@ using namespace multy_core::internal;
 class ErrorWrapperException : public Exception
 {
 public:
-    ErrorWrapperException(ErrorPtr error)
+    explicit ErrorWrapperException(ErrorPtr error)
         : ErrorWrapperException(error.get())
     {
     }
 
-    ErrorWrapperException(Error* error)
+    explicit ErrorWrapperException(Error* error)
         : Exception("", error ? error->location : CodeLocation{nullptr, 0}),
           m_error(std::move(error))
     {

--- a/multy_core/src/ethereum/ethereum_account.cpp
+++ b/multy_core/src/ethereum/ethereum_account.cpp
@@ -44,7 +44,7 @@ public:
     static const size_t DATA_SIZE = 64;
     typedef std::vector<uint8_t> KeyData;
 
-    EthereumPublicKey(KeyData key_data)
+    explicit EthereumPublicKey(KeyData key_data)
         : m_data(std::move(key_data))
     {
         if (m_data.size() != DATA_SIZE)
@@ -83,7 +83,7 @@ struct EthereumPrivateKey : public PrivateKey
 {
     typedef std::array<uint8_t, 32> KeyData;
 
-    EthereumPrivateKey(const KeyData& data) : m_data(data)
+    explicit EthereumPrivateKey(const KeyData& data) : m_data(data)
     {
     }
 

--- a/multy_core/src/golos/golos_account.cpp
+++ b/multy_core/src/golos/golos_account.cpp
@@ -83,7 +83,7 @@ class GolosPublicKey : public PublicKey
 {
 public:
     typedef std::vector<uint8_t> KeyData;
-    GolosPublicKey(KeyData data)
+    explicit GolosPublicKey(KeyData data)
         : m_data(std::move(data))
     {}
 
@@ -127,7 +127,7 @@ class GolosPrivateKey : public PrivateKey
 {
 public:
     typedef std::vector<uint8_t> KeyData;
-    GolosPrivateKey(const KeyData& data)
+    explicit GolosPrivateKey(const KeyData& data)
         : m_data(data)
     {}
 

--- a/multy_core/src/golos/golos_transaction.cpp
+++ b/multy_core/src/golos/golos_transaction.cpp
@@ -250,7 +250,7 @@ public:
 class GolosTransactionSource
 {
 public:
-    GolosTransactionSource(BlockchainType blockchain_type)
+    explicit GolosTransactionSource(BlockchainType blockchain_type)
         : properties("Source"),
           address(properties, "address", Property::REQUIRED,
                 [blockchain_type](const std::string& new_address) {
@@ -278,7 +278,7 @@ public:
 class GolosTransactionDestination
 {
 public:
-    GolosTransactionDestination(BlockchainType blockchain_type)
+    explicit GolosTransactionDestination(BlockchainType blockchain_type)
         : properties("Destination"),
           address(properties, "address", Property::REQUIRED,
                 [blockchain_type](const std::string& new_address) {

--- a/multy_test/test_mnemonic.cpp
+++ b/multy_test/test_mnemonic.cpp
@@ -31,7 +31,7 @@ struct MnemonicTestCase
     const std::string expected_mnemonic;
     const bytes expected_seed;
 
-    MnemonicTestCase(
+    explicit MnemonicTestCase(
             const char* entropy,
             const char* expected_mnemonic,
             const char* expected_seed)


### PR DESCRIPTION
Fixed following Codacy warning:
 * non-explicit contstructors;
 * member variable with the same name as in parent;