### PR TITLE
MUL-1235: Error backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(MULTY_ENABLE_SIMULATE_ERROR "Enable simulating errors in multy_core, see 
 option(BUILD_SHARED_LIBS "Build as shared libraries." OFF)
 option(MULTY_WITH_TEST_APP "Build sample app that runs the tests (consider MULTY_WITH_TESTS)." OFF)
 option(MULTY_TEST_DISABLE_DEATH_TESTS "Explicitly disable death tests." ON)
+option(MULTY_FORCE_ENABLE_ERROR_BACKTRACE "Force collecting backtrace for Release builds." OFF)
 
 project(multy C CXX)
 
@@ -35,6 +36,14 @@ else()
     message("Multy Desktop flavour.")
     add_definitions(-DMULTY_BUILD_FOR_DESKTOP=1)
     # Desktop specific options, must be prefixed with MULTY_DESKTOP_
+
+    if (UNIX)
+        if (APPLE)
+            add_definitions(-DMULTY_BUILD_FOR_OSX=1)
+        else()
+            add_definitions(-DMULTY_BUILD_FOR_UNIX=1)
+        endif()
+    endif()
 
 endif()
 

--- a/multy_core/CMakeLists.txt
+++ b/multy_core/CMakeLists.txt
@@ -16,6 +16,10 @@ if (MULTY_MORE_WARNINGS)
     endif()
 endif()
 
+if("${CMAKE_BUILD_TYPE}" MATCHES ".*Debug.*" OR MULTY_FORCE_ENABLE_ERROR_BACKTRACE)
+    add_definitions(-DMULTY_ENABLE_ERROR_BACKTRACE=1)
+endif()
+
 if (MULTY_WARNINGS_AS_ERRORS)
     add_definitions(-Werror)
 endif()
@@ -59,6 +63,7 @@ add_library(multy_core
     src/ec_key_utils.cpp
     src/hash.cpp
     src/blockchain_facade_base.cpp
+    src/backtrace.cpp
 
     src/binary_data_utility.cpp
     src/error_utility.cpp

--- a/multy_core/error.h
+++ b/multy_core/error.h
@@ -41,10 +41,13 @@ struct Error
 
     // Points to the location in code where error occured.
     struct CodeLocation location;
+
+    const char* backtrace;
 };
 
 /** Allocates Error object, assumes that message is satic and shouldn't be copied. **/
 MULTY_CORE_API struct Error* make_error(enum ErrorCode code, const char* message, struct CodeLocation location);
+MULTY_CORE_API struct Error* make_error_with_backtrace(enum ErrorCode code, const char* message, struct CodeLocation location, const char* backtrace);
 
 /** Frees Error object, can take nullptr. **/
 MULTY_CORE_API void free_error(struct Error* error);

--- a/multy_core/src/api/error.cpp
+++ b/multy_core/src/api/error.cpp
@@ -8,12 +8,17 @@
 
 #include "multy_core/common.h"
 
+#include "multy_core/src/backtrace.h"
 #include "multy_core/src/error_utility.h"
+#include "multy_core/src/utility.h"
+#include "multy_core/src/u_ptr.h"
 
 #include <stdlib.h>
 
 namespace
 {
+using namespace multy_core::internal;
+
 // Can't be const because make_error returns non-const Error.
 Error OutOfMemoryError;
 
@@ -25,7 +30,8 @@ Error* get_out_of_memory_error()
         ERROR_OUT_OF_MEMORY,
         "Failed to allocate Error object.",
         false,
-        MULTY_CODE_LOCATION
+        MULTY_CODE_LOCATION,
+        nullptr
     };
     return &OutOfMemoryError;
 }
@@ -34,10 +40,25 @@ Error* get_out_of_memory_error()
 
 Error* make_error(ErrorCode code, const char* message, CodeLocation location)
 {
+    return make_error_with_backtrace(
+            code, message, location, get_error_backtrace(1).c_str());
+}
+
+Error* make_error_with_backtrace(
+        ErrorCode code,
+        const char* message,
+        CodeLocation location,
+        const char* backtrace)
+{
     message = message ? message : "";
     try
     {
-        return new Error{code, message, false, location};
+        CharPtr backtrace_ptr{copy_string(backtrace)};
+        Error* result = new Error{
+                code, message, false, location, backtrace_ptr.get()};
+        backtrace_ptr.release();
+
+        return result;
     }
     catch(...)
     {
@@ -56,5 +77,7 @@ void free_error(Error* error)
     {
         free_string(error->message);
     }
+    free_string(error->backtrace);
+
     delete error;
 }

--- a/multy_core/src/backtrace.cpp
+++ b/multy_core/src/backtrace.cpp
@@ -1,0 +1,141 @@
+/* Copyright 2018 by Multy.io
+ * Licensed under Multy.io license.
+ *
+ * See LICENSE for details
+ */
+
+#include "multy_core/src/backtrace.h"
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+
+namespace
+{
+
+const int MAX_STACK_DEPTH = 10;
+
+} // namespace
+
+#ifdef MULTY_BUILD_FOR_ANDROID
+// this entire block is based on:
+// https://stackoverflow.com/a/35585744
+// And probably belongs to Public Domain, since there is no explicit mentioning of license.
+
+#include <unwind.h>
+#include <dlfcn.h>
+#include <cxxabi.h>
+
+namespace
+{
+struct android_backtrace_state
+{
+    void **current;
+    void **end;
+};
+
+_Unwind_Reason_Code android_unwind_callback(struct _Unwind_Context* context,
+        void* arg)
+{
+    android_backtrace_state* state = reinterpret_cast<android_backtrace_state*>(arg);
+    uintptr_t pc = _Unwind_GetIP(context);
+    if (pc)
+    {
+        if (state->current == state->end)
+        {
+            return _URC_END_OF_STACK;
+        }
+        else
+        {
+            *state->current++ = reinterpret_cast<void*>(pc);
+        }
+    }
+
+    return _URC_NO_REASON;
+}
+
+std::string get_platform_backtrace(size_t skip_frames)
+{
+    std::stringstream sstr;
+
+    const int max = MAX_STACK_DEPTH * 10;
+    void* buffer[max];
+
+    android_backtrace_state state;
+    state.current = buffer;
+    state.end = buffer + max;
+
+    _Unwind_Backtrace(android_unwind_callback, &state);
+
+    int count = (int)(state.current - buffer);
+    const int last_frame = std::min(count, static_cast<int>(MAX_STACK_DEPTH + skip_frames));
+    for (int idx = skip_frames; idx < last_frame; ++idx)
+    {
+        const void* addr = buffer[idx];
+        const char* symbol = "";
+
+        Dl_info info;
+        if (dladdr(addr, &info) && info.dli_sname)
+        {
+            symbol = info.dli_sname;
+        }
+        int status = 0;
+        std::unique_ptr<char, decltype(free)*> demangled(
+                __cxxabiv1::__cxa_demangle(symbol, 0, 0, &status), &free);
+
+        sstr << idx << ": 0x" << addr << " "
+                << ((demangled && status != 0) ? demangled.get() : symbol)
+                << '\n';
+    }
+
+    return sstr.str();
+}
+} // namespace
+
+#elif defined(MULTY_BUILD_FOR_IOS) || defined(MULTY_BUILD_FOR_OSX) || defined(MULTY_BUILD_FOR_UNIX)
+// This entire block is based on `man backtrace`
+#include <execinfo.h>
+
+namespace
+{
+
+std::string get_platform_backtrace(size_t skip_frames)
+{
+    std::stringstream sstr;
+
+    const int max = MAX_STACK_DEPTH * 10;
+    void* callstack[max];
+    const int frames = backtrace(callstack, max);
+    std::unique_ptr<char*[], decltype(free)*> strs(
+            backtrace_symbols(callstack, frames),
+            &free);
+
+    const int last_frame = std::min(frames, static_cast<int>(MAX_STACK_DEPTH + skip_frames));
+    for (int i = skip_frames; i < last_frame; ++i)
+    {
+        sstr << strs[i] << '\n';
+    }
+
+    return sstr.str();
+}
+
+} // namespace
+
+#else
+std::string get_platform_backtrace(size_t /*skip_frames*/)
+{
+    (void)(MAX_STACK_DEPTH);
+    static_assert(false, "backtrace not supported.");
+}
+#endif
+
+std::string get_backtrace(size_t skip_frames)
+{
+    // +1 is for get_backtrace()
+    // +1 is for get_platform_backtrace()
+    // + 1 is for native backtrace taking function.
+    const size_t new_skip_frames =
+            std::min(static_cast<int>(skip_frames + 3), MAX_STACK_DEPTH - 1);
+
+    return get_platform_backtrace(new_skip_frames);
+}

--- a/multy_core/src/backtrace.h
+++ b/multy_core/src/backtrace.h
@@ -1,0 +1,17 @@
+/* Copyright 2018 by Multy.io
+ * Licensed under Multy.io license.
+ *
+ * See LICENSE for details
+ */
+
+#ifndef MULTY_CORE_BACKTRACE_H
+#define MULTY_CORE_BACKTRACE_H
+
+#include "multy_core/api.h"
+
+#include <cstddef>
+#include <string>
+
+MULTY_CORE_API std::string get_backtrace(size_t skip_frames = 0);
+
+#endif // MULTY_CORE_BACKTRACE_H

--- a/multy_core/src/error_utility.h
+++ b/multy_core/src/error_utility.h
@@ -16,6 +16,7 @@
 #include "multy_core/error.h"
 
 #include <cassert>
+#include <string>
 
 struct Error;
 
@@ -98,6 +99,9 @@ namespace multy_core
 {
 namespace internal
 {
+
+// Can return empty string if taking error backtrace is disabled.
+MULTY_CORE_API std::string get_error_backtrace(size_t ignore_frames);
 
 MULTY_CORE_API void throw_if_error(struct Error* err);
 

--- a/multy_core/src/exception.cpp
+++ b/multy_core/src/exception.cpp
@@ -7,7 +7,9 @@
 #include "multy_core/src/exception.h"
 
 #include "multy_core/error.h"
+#include "multy_core/src/backtrace.h"
 #include "multy_core/src/utility.h"
+#include "multy_core/src/error_utility.h"
 
 #include <iostream>
 
@@ -19,17 +21,20 @@ namespace internal
 Exception::Exception(
         ErrorCode error_code,
         const char* message,
-        CodeLocation location)
+        CodeLocation location,
+        const char* backtrace)
     : m_error_code(error_code),
-      m_message(message),
-      m_location(location)
+      m_message((message ? message : "")),
+      m_location(location),
+      m_backtrace(backtrace ? backtrace : get_error_backtrace(2))
 {
 }
 
 Exception::Exception(
         const char* message,
-        CodeLocation location)
-    : Exception(ERROR_GENERAL_ERROR, message, location)
+        CodeLocation location,
+        const char* backtrace)
+    : Exception(ERROR_GENERAL_ERROR, message, location, backtrace)
 {
 }
 
@@ -45,7 +50,9 @@ const char* Exception::what() const noexcept
 Error* Exception::make_error() const
 {
     CharPtr message(copy_string(m_message));
-    Error* result = ::make_error(m_error_code, message.get(), m_location);
+    Error* result = ::make_error_with_backtrace(
+            m_error_code, message.get(), m_location, m_backtrace.c_str());
+
     result->owns_message = true;
     message.release();
 

--- a/multy_core/src/exception.h
+++ b/multy_core/src/exception.h
@@ -22,7 +22,7 @@ namespace internal
 
 /** Exception class used in multy_core.
  *
- * Message can be modified with append_message() and\or overloaded operator<<().
+ * Message can be modified with append_message() and/or overloaded operator<<().
  *
  * Please use THROW_EXCEPTION() to throw Exception with proper CodeLocation set.
  *
@@ -33,8 +33,15 @@ namespace internal
 class MULTY_CORE_API Exception : public std::exception
 {
 public:
-    Exception(ErrorCode error_code, const char* message, CodeLocation location);
-    Exception(const char* message, CodeLocation location);
+    Exception(ErrorCode error_code,
+            const char* message,
+            CodeLocation location,
+            const char* backtrace = nullptr);
+
+    Exception(const char* message,
+            CodeLocation location,
+            const char* backtrace = nullptr);
+
     virtual ~Exception();
 
     virtual Error* make_error() const;
@@ -47,6 +54,7 @@ private:
     const ErrorCode m_error_code;
     mutable std::string m_message;
     const CodeLocation m_location;
+    const std::string m_backtrace;
 };
 
 #define THROW_EXCEPTION(msg) \

--- a/multy_test/value_printers.cpp
+++ b/multy_test/value_printers.cpp
@@ -82,6 +82,10 @@ void PrintTo(const Error& e, std::ostream* out)
     {
         *out << " @ " << e.location.file << " : " << e.location.line;
     }
+    if (e.backtrace && strlen(e.backtrace) > 0)
+    {
+        *out << "\nBacktrace:\n" << e.backtrace;
+    }
 }
 
 void PrintTo(const BinaryData& data, std::ostream* out)


### PR DESCRIPTION
Implemented getting backtrace when generating an Error and\or throwing Exception;
get_backtrace() should work for Android, iOS, OSX, and Linux.