### PR TITLE
MUL-1111: Extend BigInt API

### DIFF
--- a/multy_core/big_int.h
+++ b/multy_core/big_int.h
@@ -9,6 +9,8 @@
 
 #include "multy_core/api.h"
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,13 +21,35 @@ struct Error;
 MULTY_CORE_API struct Error* make_big_int(
         const char* value, struct BigInt** new_big_int);
 
-MULTY_CORE_API struct Error* big_int_to_string(
+MULTY_CORE_API struct Error* make_big_int_from_int64(
+        int64_t value, struct BigInt** new_big_int);
+
+MULTY_CORE_API struct Error* big_int_get_value(
         const struct BigInt* big_int, const char** out_string_value);
 
 MULTY_CORE_API struct Error* big_int_set_value(
         struct BigInt* big_int, const char* value);
 
+MULTY_CORE_API struct Error* big_int_get_int64_value(
+        const struct BigInt* big_int, int64_t* out_value);
+
+MULTY_CORE_API struct Error* big_int_set_int64_value(
+        struct BigInt* big_int, int64_t value);
+
+MULTY_CORE_API struct Error* big_int_add(struct BigInt* target, const struct BigInt* value);
+MULTY_CORE_API struct Error* big_int_add_int64(struct BigInt* target, int64_t value);
+
+MULTY_CORE_API struct Error* big_int_sub(struct BigInt* target, const struct BigInt* value);
+MULTY_CORE_API struct Error* big_int_sub_int64(struct BigInt* target, int64_t value);
+
+MULTY_CORE_API struct Error* big_int_mul(struct BigInt* target, const struct BigInt* value);
+MULTY_CORE_API struct Error* big_int_mul_int64(struct BigInt* target, int64_t value);
+
+MULTY_CORE_API struct Error* big_int_div(struct BigInt* target, const struct BigInt* value);
+MULTY_CORE_API struct Error* big_int_div_int64(struct BigInt* target, int64_t value);
+
 MULTY_CORE_API void free_big_int(struct BigInt*);
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/multy_core/error.h
+++ b/multy_core/error.h
@@ -9,6 +9,8 @@
 
 #include "multy_core/api.h"
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,7 +37,7 @@ struct CodeLocation
  */
 struct Error
 {
-    ErrorCode code;
+    enum ErrorCode code;
     const char* message;
     bool owns_message;
 

--- a/multy_core/src/api/big_int.cpp
+++ b/multy_core/src/api/big_int.cpp
@@ -26,9 +26,24 @@ Error* make_big_int(const char* value, BigInt** new_big_int)
     return nullptr;
 }
 
-Error* big_int_to_string(const BigInt* big_int, const char** out_string_value)
+Error* make_big_int_from_int64(int64_t value, BigInt** new_big_int)
 {
-    ARG_CHECK(big_int);
+    ARG_CHECK(new_big_int);
+
+    try
+    {
+        *new_big_int = new BigInt(value);
+    }
+    CATCH_EXCEPTION_RETURN_ERROR();
+
+    OUT_CHECK_OBJECT(*new_big_int);
+
+    return nullptr;
+}
+
+Error* big_int_get_value(const BigInt* big_int, const char** out_string_value)
+{
+    ARG_CHECK_OBJECT(big_int);
     ARG_CHECK(out_string_value);
 
     try
@@ -45,7 +60,7 @@ Error* big_int_to_string(const BigInt* big_int, const char** out_string_value)
 
 Error* big_int_set_value(BigInt* big_int, const char* value)
 {
-    ARG_CHECK(big_int);
+    ARG_CHECK_OBJECT(big_int);
     ARG_CHECK(value);
 
     try
@@ -53,6 +68,116 @@ Error* big_int_set_value(BigInt* big_int, const char* value)
         big_int->set_value(value);
     }
     CATCH_EXCEPTION_RETURN_ERROR();
+
+    return nullptr;
+}
+
+Error* big_int_get_int64_value(const BigInt* big_int, int64_t* out_value)
+{
+    ARG_CHECK_OBJECT(big_int);
+    ARG_CHECK(out_value);
+
+    try
+    {
+        *out_value = big_int->get_value_as_int64();
+    }
+    CATCH_EXCEPTION_RETURN_ERROR();
+
+    return nullptr;
+}
+
+Error* big_int_set_int64_value(BigInt* big_int, int64_t value)
+{
+    ARG_CHECK_OBJECT(big_int);
+
+    try
+    {
+        big_int->set_value_int64(value);
+    }
+    CATCH_EXCEPTION_RETURN_ERROR();
+
+    return nullptr;
+}
+
+#define BIG_INT_OP(statement) \
+    try \
+    { \
+        statement; \
+    } \
+    CATCH_EXCEPTION_RETURN_ERROR()
+
+Error* big_int_add(BigInt* target, const BigInt* value)
+{
+    ARG_CHECK_OBJECT(target);
+    ARG_CHECK_OBJECT(value);
+
+    BIG_INT_OP(*target += *value);
+
+    return nullptr;
+}
+
+Error* big_int_add_int64(BigInt* target, int64_t value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target += value);
+
+    return nullptr;
+}
+
+Error* big_int_sub(BigInt* target, const BigInt* value)
+{
+    ARG_CHECK_OBJECT(target);
+    ARG_CHECK_OBJECT(value);
+
+    BIG_INT_OP(*target -= *value);
+
+    return nullptr;
+}
+
+Error* big_int_sub_int64(BigInt* target, int64_t value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target -= value);
+
+    return nullptr;
+}
+
+Error* big_int_mul(BigInt* target, const BigInt* value)
+{
+    ARG_CHECK_OBJECT(target);
+    ARG_CHECK_OBJECT(value);
+
+    BIG_INT_OP(*target *= *value);
+
+    return nullptr;
+}
+
+Error* big_int_mul_int64(BigInt* target, int64_t value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target *= value);
+
+    return nullptr;
+}
+
+Error* big_int_div(BigInt* target, const BigInt* value)
+{
+    ARG_CHECK_OBJECT(target);
+    ARG_CHECK_OBJECT(value);
+
+    BIG_INT_OP(*target /= *value);
+
+    return nullptr;
+}
+
+Error* big_int_div_int64(BigInt* target, int64_t value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target /= value);
 
     return nullptr;
 }

--- a/multy_core/src/api/big_int_impl.h
+++ b/multy_core/src/api/big_int_impl.h
@@ -39,9 +39,14 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     BigInt(const BigInt& other);
     BigInt& operator=(const BigInt& other);
 
+    BigInt(BigInt&& other);
+    BigInt& operator=(BigInt&& other);
+
     ~BigInt();
 
     void set_value(const char* value);
+    void set_value_int64(int64_t value);
+
     std::string get_value() const;
 
     // Returns value as int64_t, throws exception if value is too big.
@@ -62,6 +67,8 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     BigInt& operator+=(const BigInt& other);
     BigInt& operator-=(const BigInt& other);
     BigInt& operator*=(const BigInt& other);
+    BigInt& operator/=(const BigInt& other);
+    BigInt operator-() const;
 
     template <typename T>
     BigInt& operator+=(const T& value)
@@ -79,6 +86,11 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     BigInt& operator*=(const T& value)
     {
         return *this *= BigInt(value);
+    }
+    template <typename T>
+    BigInt& operator/=(const T& value)
+    {
+        return *this /= BigInt(value);
     }
 
     bool operator==(const BigInt& other) const;
@@ -148,6 +160,7 @@ inline std::string BigInt::get<std::string>() const
 MULTY_BIG_INT_DEFINE_OP(+)
 MULTY_BIG_INT_DEFINE_OP(-)
 MULTY_BIG_INT_DEFINE_OP(*)
+MULTY_BIG_INT_DEFINE_OP(/)
 
 #undef MULTY_BIG_INT_DEFINE_OP
 

--- a/multy_test/utility.cpp
+++ b/multy_test/utility.cpp
@@ -9,6 +9,9 @@
 #include "multy_core/account.h"
 #include "multy_core/common.h"
 #include "multy_core/src/api/key_impl.h"
+
+#include "multy_test/value_printers.h"
+
 #include "wally_core.h"
 
 #include <exception>
@@ -91,6 +94,17 @@ EntropySource make_dummy_entropy_source()
 void throw_exception(const char* message)
 {
     throw std::runtime_error(message);
+}
+
+void throw_exception_if_error(const Error* error)
+{
+    if (error)
+    {
+        std::stringstream sstr;
+        PrintTo(*error, &sstr);
+
+        throw_exception(sstr.str().c_str());
+    }
 }
 
 bool blockchain_can_derive_address_from_private_key(Blockchain blockchain)

--- a/multy_test/utility.h
+++ b/multy_test/utility.h
@@ -53,6 +53,7 @@ multy_core::internal::ExtendedKeyPtr make_dummy_extended_key_ptr();
 EntropySource make_dummy_entropy_source();
 
 void throw_exception(const char* message);
+void throw_exception_if_error(const Error* message);
 bool blockchain_can_derive_address_from_private_key(Blockchain blockchain);
 
 std::string minify_json(const std::string &input_json);


### PR DESCRIPTION
Renamed big_int_to_string() into big_int_get_value()
Added:
 * make_big_int_from_int64()
 * big_int_get_int64_value()
 * big_int_set_int64_value()
 * big_int_add()
 * big_int_add_int64()
 * big_int_sub()
 * big_int_sub_int64()
 * big_int_mul()
 * big_int_mul_int64()
 * big_int_div()
 * big_int_div_int64()

Added few test cases to verify validition of arithmetic operations;