### PR TITLE
MUL-1343: Implemented BigInt API for double math

### DIFF
--- a/multy_core/big_int.h
+++ b/multy_core/big_int.h
@@ -21,6 +21,9 @@ struct Error;
 MULTY_CORE_API struct Error* make_big_int(
         const char* value, struct BigInt** new_big_int);
 
+MULTY_CORE_API struct Error* make_big_int_clone(
+        const struct BigInt* original, struct BigInt** new_big_int);
+
 MULTY_CORE_API struct Error* make_big_int_from_int64(
         int64_t value, struct BigInt** new_big_int);
 
@@ -38,15 +41,23 @@ MULTY_CORE_API struct Error* big_int_set_int64_value(
 
 MULTY_CORE_API struct Error* big_int_add(struct BigInt* target, const struct BigInt* value);
 MULTY_CORE_API struct Error* big_int_add_int64(struct BigInt* target, int64_t value);
+MULTY_CORE_API struct Error* big_int_add_double(struct BigInt* target, double value);
 
 MULTY_CORE_API struct Error* big_int_sub(struct BigInt* target, const struct BigInt* value);
 MULTY_CORE_API struct Error* big_int_sub_int64(struct BigInt* target, int64_t value);
+MULTY_CORE_API struct Error* big_int_sub_double(struct BigInt* target, double value);
 
 MULTY_CORE_API struct Error* big_int_mul(struct BigInt* target, const struct BigInt* value);
 MULTY_CORE_API struct Error* big_int_mul_int64(struct BigInt* target, int64_t value);
+MULTY_CORE_API struct Error* big_int_mul_double(struct BigInt* target, double value);
 
 MULTY_CORE_API struct Error* big_int_div(struct BigInt* target, const struct BigInt* value);
 MULTY_CORE_API struct Error* big_int_div_int64(struct BigInt* target, int64_t value);
+MULTY_CORE_API struct Error* big_int_div_double(struct BigInt* target, double value);
+
+MULTY_CORE_API struct Error* big_int_cmp(struct BigInt* left, struct BigInt* right, int* out_result);
+MULTY_CORE_API struct Error* big_int_cmp_int64(struct BigInt* left, int64_t right, int* out_result);
+MULTY_CORE_API struct Error* big_int_cmp_double(struct BigInt* left, double right, int* out_result);
 
 MULTY_CORE_API void free_big_int(struct BigInt*);
 

--- a/multy_core/src/api/big_int.cpp
+++ b/multy_core/src/api/big_int.cpp
@@ -26,6 +26,22 @@ Error* make_big_int(const char* value, BigInt** new_big_int)
     return nullptr;
 }
 
+Error* make_big_int_clone(const BigInt* original, BigInt** new_big_int)
+{
+    ARG_CHECK_OBJECT(original);
+    ARG_CHECK(new_big_int);
+
+    try
+    {
+        *new_big_int = new BigInt(*original);
+    }
+    CATCH_EXCEPTION_RETURN_ERROR();
+
+    OUT_CHECK_OBJECT(*new_big_int);
+
+    return nullptr;
+}
+
 Error* make_big_int_from_int64(int64_t value, BigInt** new_big_int)
 {
     ARG_CHECK(new_big_int);
@@ -125,6 +141,16 @@ Error* big_int_add_int64(BigInt* target, int64_t value)
     return nullptr;
 }
 
+Error* big_int_add_double(BigInt* target, double value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target += value);
+
+    return nullptr;
+}
+
+
 Error* big_int_sub(BigInt* target, const BigInt* value)
 {
     ARG_CHECK_OBJECT(target);
@@ -136,6 +162,15 @@ Error* big_int_sub(BigInt* target, const BigInt* value)
 }
 
 Error* big_int_sub_int64(BigInt* target, int64_t value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target -= value);
+
+    return nullptr;
+}
+
+Error* big_int_sub_double(BigInt* target, double value)
 {
     ARG_CHECK_OBJECT(target);
 
@@ -163,6 +198,15 @@ Error* big_int_mul_int64(BigInt* target, int64_t value)
     return nullptr;
 }
 
+Error* big_int_mul_double(BigInt* target, double value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target *= value);
+
+    return nullptr;
+}
+
 Error* big_int_div(BigInt* target, const BigInt* value)
 {
     ARG_CHECK_OBJECT(target);
@@ -178,6 +222,46 @@ Error* big_int_div_int64(BigInt* target, int64_t value)
     ARG_CHECK_OBJECT(target);
 
     BIG_INT_OP(*target /= value);
+
+    return nullptr;
+}
+
+Error* big_int_div_double(BigInt* target, double value)
+{
+    ARG_CHECK_OBJECT(target);
+
+    BIG_INT_OP(*target /= value);
+
+    return nullptr;
+}
+
+Error* big_int_cmp(struct BigInt* left, struct BigInt* right, int* out_result)
+{
+    ARG_CHECK_OBJECT(left);
+    ARG_CHECK_OBJECT(right);
+    ARG_CHECK(out_result);
+
+    BIG_INT_OP(*out_result = left->compare(*right));
+
+    return nullptr;
+}
+
+Error* big_int_cmp_int64(struct BigInt* left, int64_t right, int* out_result)
+{
+    ARG_CHECK_OBJECT(left);
+    ARG_CHECK(out_result);
+
+    BIG_INT_OP(*out_result = left->compare(right));
+
+    return nullptr;
+}
+
+Error* big_int_cmp_double(struct BigInt* left, double right, int* out_result)
+{
+    ARG_CHECK_OBJECT(left);
+    ARG_CHECK(out_result);
+
+    BIG_INT_OP(*out_result = left->compare(right));
 
     return nullptr;
 }

--- a/multy_core/src/api/big_int_impl.h
+++ b/multy_core/src/api/big_int_impl.h
@@ -34,6 +34,7 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     explicit BigInt(int32_t value = 0);
     explicit BigInt(int64_t value);
     explicit BigInt(uint64_t value);
+    explicit BigInt(double value);
     // TODO: implement template constructor that would choose appropriate overload based on signess and size of the int argument.
 
     BigInt(const BigInt& other);
@@ -52,6 +53,8 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     // Returns value as int64_t, throws exception if value is too big.
     int64_t get_value_as_int64() const;
 
+    bool is_representable_as_int64() const;
+
     // Returns value as uint64_t, throws exception if value is too big.
     uint64_t get_value_as_uint64() const;
 
@@ -68,6 +71,12 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     BigInt& operator-=(const BigInt& other);
     BigInt& operator*=(const BigInt& other);
     BigInt& operator/=(const BigInt& other);
+
+    BigInt& operator+=(const double& value);
+    BigInt& operator-=(const double& value);
+    BigInt& operator*=(const double& value);
+    BigInt& operator/=(const double& value);
+
     BigInt operator-() const;
 
     template <typename T>
@@ -92,6 +101,18 @@ struct MULTY_CORE_API BigInt : public ::multy_core::internal::ObjectBase<BigInt>
     {
         return *this /= BigInt(value);
     }
+
+    /** C-style comparison:
+     * almost equivalent to this - other
+     *
+     * @return:
+     *      <0  if this < other
+     *      ==0 if this == other
+     *      >0  if this > other
+     */
+    int compare(const BigInt& other) const;
+    int compare(const int64_t& other) const;
+    int compare(const double& other) const;
 
     bool operator==(const BigInt& other) const;
     bool operator!=(const BigInt& other) const;


### PR DESCRIPTION
Added API methods that do addition, substraction, multiplication and division on double;
Added API methods to compare BigInt to BigInt, int64 and double;
Added API method make_big_int_clone();
Updated tests to verify correctness of comparison and math operations with double;
Added tests for math with special double values: NaN, -INF, +INF;
Added tests for make_big_int_clone().