### PR TITLE
MUL-1398: CI memory sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,7 @@ matrix:
 
 before_script:
     - eval "${MATRIX_EVAL}"
+    - echo "ASAN_OPTIONS: $ASAN_OPTIONS"
 
 script:
   - mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,30 @@ matrix:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - BUILD_TYPE=Release
 
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+        - BUILD_TYPE=Release
+        - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+        - BUILD_TYPE=Debug
+        - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
+
     - language: android
       jdk: oraclejdk8
       os: linux
@@ -130,6 +154,6 @@ before_script:
 
 script:
   - mkdir build && cd build
-  - cmake .. -G'Unix Makefiles' -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMULTY_MORE_WARNINGS=ON -DMULTY_TEST_DISABLE_DEATH_TESTS=ON -DMULTY_WARNINGS_AS_ERRORS=ON -DMULTY_WITH_TESTS=ON -DMULTY_WITH_TEST_APP=ON
+  - cmake .. -G'Unix Makefiles' -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMULTY_MORE_WARNINGS=ON -DMULTY_TEST_DISABLE_DEATH_TESTS=ON -DMULTY_WARNINGS_AS_ERRORS=ON -DMULTY_WITH_TESTS=ON -DMULTY_WITH_TEST_APP=ON ${EXTRA_CMAKE_OPTIONS}
   - cmake --build . --target all
   - ./multy

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       env:
         - BUILD_TYPE=Debug
         - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
-        - MATRIX_EVAL="ASAN_OPTIONS=detect_container_overflow=0"
+        - MATRIX_EVAL="export ASAN_OPTIONS=detect_container_overflow=0"
 
     - language: android
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,6 @@ matrix:
 
 before_script:
     - eval "${MATRIX_EVAL}"
-    - echo "ASAN_OPTIONS: $ASAN_OPTIONS"
 
 script:
   - mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,54 +10,49 @@ os:
 matrix:
   fast_finish: true
   include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-        - BUILD_TYPE=Debug
+    #- os: linux
+      #addons:
+        #apt:
+          #sources:
+            #- ubuntu-toolchain-r-test
+          #packages:
+            #- g++-5
+      #env:
+        #- MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+        #- BUILD_TYPE=Debug
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-        - BUILD_TYPE=Release
+    #- os: linux
+      #addons:
+        #apt:
+          #sources:
+            #- ubuntu-toolchain-r-test
+          #packages:
+            #- g++-5
+      #env:
+        #- MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+        #- BUILD_TYPE=Release
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
-        - BUILD_TYPE=Debug
+    #- os: linux
+      #addons:
+        #apt:
+          #sources:
+            #- ubuntu-toolchain-r-test
+          #packages:
+            #- g++-5
+      #env:
+        #- MATRIX_EVAL="CC=clang && CXX=clang++"
+        #- BUILD_TYPE=Debug
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
-        - BUILD_TYPE=Release
-
-    - os: osx
-      env:
-        - BUILD_TYPE=Release
-        - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
+    #- os: linux
+      #addons:
+        #apt:
+          #sources:
+            #- ubuntu-toolchain-r-test
+          #packages:
+            #- g++-5
+      #env:
+        #- MATRIX_EVAL="CC=clang && CXX=clang++"
+        #- BUILD_TYPE=Release
 
     - os: osx
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       env:
         - BUILD_TYPE=Debug
         - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
-        - MATRIX_EVAL="export ASAN_OPTIONS=detect_container_overflow=0"
+        - MATRIX_EVAL="ASAN_OPTIONS=detect_container_overflow=0"
 
     - language: android
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,27 +54,13 @@ matrix:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - BUILD_TYPE=Release
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
+    - os: osx
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
         - BUILD_TYPE=Release
         - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
+    - os: osx
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
         - BUILD_TYPE=Debug
         - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
       env:
         - BUILD_TYPE=Debug
         - EXTRA_CMAKE_OPTIONS=-DMULTY_TEST_WITH_MEMORY_SANITIZER=1
+        - MATRIX_EVAL="export ASAN_OPTIONS=detect_container_overflow=0"
 
     - language: android
       jdk: oraclejdk8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # General options
-option(MULTY_WITH_TESTS "Build multy_test library" NO)
 option(MULTY_MORE_WARNINGS "More warnings" OFF)
 option(MULTY_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(MULTY_ENABLE_SIMULATE_ERROR "Enable simulating errors in multy_core, see THROW_IF_WALLY_ERROR for details." OFF)
 # This is a standard CMake option, but we are putting it here to emphasise.
 option(BUILD_SHARED_LIBS "Build as shared libraries." OFF)
+option(MULTY_FORCE_ENABLE_ERROR_BACKTRACE "Force collecting backtrace for Release builds." OFF)
+
+# Tests options
 option(MULTY_WITH_TEST_APP "Build sample app that runs the tests (consider MULTY_WITH_TESTS)." OFF)
 option(MULTY_TEST_DISABLE_DEATH_TESTS "Explicitly disable death tests." ON)
-option(MULTY_FORCE_ENABLE_ERROR_BACKTRACE "Force collecting backtrace for Release builds." OFF)
+option(MULTY_TEST_WITH_MEMORY_SANITIZER "Enable memory sanitizer for multy_test." OFF)
 
 project(multy C CXX)
 

--- a/multy_test/CMakeLists.txt
+++ b/multy_test/CMakeLists.txt
@@ -76,13 +76,12 @@ if (MULTY_TEST_WITH_MEMORY_SANITIZER)
         multy_test
         PUBLIC
         -fsanitize=address -fno-omit-frame-pointer
-        -fsanitize=undefined
     )
 
     target_link_libraries(
         multy_test
         PUBLIC
-        $<$<CONFIG:Debug>:-fsanitize=address>
+        -fsanitize=address
     )
 endif()
 

--- a/multy_test/CMakeLists.txt
+++ b/multy_test/CMakeLists.txt
@@ -71,6 +71,21 @@ target_link_libraries(
     libwally-core
 )
 
+if (MULTY_TEST_WITH_MEMORY_SANITIZER)
+    target_compile_options(
+        multy_test
+        PUBLIC
+        -fsanitize=address -fno-omit-frame-pointer
+        -fsanitize=undefined
+    )
+
+    target_link_libraries(
+        multy_test
+        PUBLIC
+        $<$<CONFIG:Debug>:-fsanitize=address>
+    )
+endif()
+
 if (MULTY_TEST_DISABLE_DEATH_TESTS)
     target_compile_definitions(multy_test PRIVATE MULTY_TEST_DISABLE_DEATH_TESTS)
     message("DEATH tests disabled.")


### PR DESCRIPTION
Added option MULTY_TEST_WITH_MEMORY_SANITIZER that enables Clang-based memory sanitizer for multy_test;
Added TravisCI matrix builds to execute tests build with memory sanitization.