### PR TITLE
MUL-1451: SegWit wallet API

### DIFF
--- a/multy_core/CMakeLists.txt
+++ b/multy_core/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(multy_core
     bitcoin.h
     src/bitcoin/bitcoin_facade.cpp
     src/bitcoin/bitcoin_account.cpp
+    src/bitcoin/bitcoin_key.cpp
     src/bitcoin/bitcoin_transaction.cpp
 
     # Ethereum

--- a/multy_core/account.h
+++ b/multy_core/account.h
@@ -35,16 +35,23 @@ enum KeyType
     KEY_TYPE_PUBLIC,
 };
 
+enum AccountType
+{
+    ACCOUNT_TYPE_DEFAULT = 0
+};
+
 /** Make an account of given BlockchainType with given id.
  *
  * @param master_key - master key, generated from seed.
  * @param BlockchainType - Blockchain to use account for.
+ * @param account_type - ACCOUNT_TYPE_DEFAULT or blockchain-specific account type.
  * @param index - acccount index
  * @param account - (out) new account
  */
 MULTY_CORE_API struct Error* make_hd_account(
         const struct ExtendedKey* master_key,
         struct BlockchainType blockchain_type,
+        uint32_t account_type,
         uint32_t index,
         struct HDAccount** new_account);
 
@@ -63,12 +70,14 @@ MULTY_CORE_API struct Error* make_hd_leaf_account(
 
 /** Make regular account from private key and Blockchain.
  * @param Blockchain - Blockchain to use account for.
+ * @param account_type - ACCOUNT_TYPE_DEFAULT or blockchain-specific account type.
  * @param serialized_private_key - private key for account.
  * @param new_account - newly created account, must be freed by caller with
  * free_account().
  */
 MULTY_CORE_API struct Error* make_account(
         struct BlockchainType blockchain,
+        uint32_t account_type,
         const char* serialized_private_key,
         struct Account** new_account);
 

--- a/multy_core/bitcoin.h
+++ b/multy_core/bitcoin.h
@@ -21,6 +21,14 @@ enum BitcoinAddressType
 {
     BITCOIN_ADDRESS_P2PKH = 0,
     BITCOIN_ADDRESS_P2SH = 1,
+    BITCOIN_ADDRESS_P2SH_P2WPKH = 2
+};
+
+enum BitcoinAccountType
+{
+    BITCOIN_ACCOUNT_DEFAULT = 0,
+    BITCOIN_ACCOUNT_P2PKH = BITCOIN_ACCOUNT_DEFAULT,
+    BITCOIN_ACCOUNT_SEGWIT = 1,
 };
 
 #ifdef __cplusplus

--- a/multy_core/src/api/account.cpp
+++ b/multy_core/src/api/account.cpp
@@ -26,6 +26,7 @@ using namespace multy_core::internal;
 Error* make_hd_account(
         const ExtendedKey* master_key,
         BlockchainType blockchain_type,
+        uint32_t account_type,
         uint32_t index,
         HDAccount** new_account)
 {
@@ -36,7 +37,8 @@ Error* make_hd_account(
     try
     {
         *new_account = get_blockchain(blockchain_type.blockchain)
-                .make_hd_account(blockchain_type, *master_key, index).release();
+                .make_hd_account(blockchain_type, account_type,
+                        *master_key, index).release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_ACCOUNT);
 
@@ -71,6 +73,7 @@ Error* make_hd_leaf_account(
 
 Error* make_account(
         BlockchainType blockchain,
+        uint32_t account_type,
         const char* serialized_private_key,
         Account** new_account)
 {
@@ -83,7 +86,8 @@ Error* make_account(
     try
     {
         *new_account = get_blockchain(blockchain.blockchain)
-                .make_account(blockchain, serialized_private_key).release();
+                .make_account(blockchain, account_type, serialized_private_key)
+                .release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_ACCOUNT);
 

--- a/multy_core/src/bitcoin/bitcoin_account.h
+++ b/multy_core/src/bitcoin/bitcoin_account.h
@@ -18,14 +18,18 @@ namespace multy_core
 namespace internal
 {
 
+class BitcoinAccount;
 struct BitcoinPublicKey;
 struct BitcoinPrivateKey;
+typedef UPtr<BitcoinAccount> BitcoinAccountPtr;
 typedef UPtr<BitcoinPrivateKey> BitcoinPrivateKeyPtr;
 typedef UPtr<BitcoinPublicKey> BitcoinPublicKeyPtr;
 
 void bitcoin_hash_160(const BinaryData& input, BinaryData* output);
 
-AccountPtr make_bitcoin_account(const char* private_key);
+AccountPtr make_bitcoin_account(
+        const char* private_key,
+        BitcoinAccountType account_type);
 
 /** Parse given base58 encoded address and verify it's checksumm.
  *
@@ -46,6 +50,7 @@ class MULTY_CORE_API BitcoinHDAccount : public HDAccountBase
 public:
     BitcoinHDAccount(
             BlockchainType blockchain_type,
+            BitcoinAccountType account_type,
             const ExtendedKey& bip44_master_key,
             uint32_t index);
 
@@ -55,19 +60,27 @@ public:
             const ExtendedKey& parent_key,
             AddressType type,
             uint32_t index) const override;
+
+private:
+    const BitcoinAccountType m_account_type;
 };
 
 class MULTY_CORE_API BitcoinAccount : public AccountBase
 {
 public:
-    BitcoinAccount(BlockchainType blockchain_type, BitcoinPrivateKeyPtr key, HDPath path);
+    BitcoinAccount(
+            BlockchainType blockchain_type,
+            BitcoinPrivateKeyPtr key,
+            HDPath path);
+
     ~BitcoinAccount();
 
-    std::string get_address() const override;
+    virtual std::string get_address() const = 0;
 
     static std::string get_address_from_private_key(const PrivateKey& key);
+    BitcoinAccountType get_account_type() const;
 
-private:
+protected:
     const BitcoinPrivateKeyPtr m_private_key;
 };
 

--- a/multy_core/src/bitcoin/bitcoin_facade.cpp
+++ b/multy_core/src/bitcoin/bitcoin_facade.cpp
@@ -18,6 +18,24 @@
 namespace
 {
 using namespace multy_core::internal;
+
+BitcoinAccountType to_bitcoin_account_type(uint32_t account_type)
+{
+    switch (account_type)
+    {
+        case BITCOIN_ACCOUNT_DEFAULT:
+            return BITCOIN_ACCOUNT_DEFAULT;
+        case BITCOIN_ACCOUNT_SEGWIT:
+            return BITCOIN_ACCOUNT_SEGWIT;
+        default:
+            THROW_EXCEPTION2(ERROR_INVALID_ARGUMENT,
+                    "Unknown Bitcoin Account type.")
+                    << " Got: " << account_type << ".";
+    }
+
+    return BITCOIN_ACCOUNT_DEFAULT;
+}
+
 } // namespace
 
 namespace multy_core
@@ -33,15 +51,26 @@ BitcoinFacade::~BitcoinFacade()
 {
 }
 
-HDAccountPtr BitcoinFacade::make_hd_account(BlockchainType blockchain_type,
-        const ExtendedKey& master_key, uint32_t index)
+HDAccountPtr BitcoinFacade::make_hd_account(
+        BlockchainType blockchain_type,
+        uint32_t account_type,
+        const ExtendedKey& master_key,
+        uint32_t index)
 {
-    return HDAccountPtr(new BitcoinHDAccount(blockchain_type, master_key, index));
+    return HDAccountPtr(new BitcoinHDAccount(
+            blockchain_type,
+            to_bitcoin_account_type(account_type),
+            master_key,
+        index));
 }
 
-AccountPtr BitcoinFacade::make_account(BlockchainType blockchain_type, const char* serialized_private_key)
+AccountPtr BitcoinFacade::make_account(
+        BlockchainType blockchain_type,
+        uint32_t account_type,
+        const char* serialized_private_key)
 {
-    AccountPtr account = make_bitcoin_account(serialized_private_key);
+    AccountPtr account = make_bitcoin_account(serialized_private_key,
+            to_bitcoin_account_type(account_type));
     if (account->get_blockchain_type() != blockchain_type)
     {
         THROW_EXCEPTION("Private key doesn't match requested blockchain type.")

--- a/multy_core/src/bitcoin/bitcoin_facade.h
+++ b/multy_core/src/bitcoin/bitcoin_facade.h
@@ -20,9 +20,17 @@ public:
     BitcoinFacade();
     ~BitcoinFacade();
 
-    HDAccountPtr make_hd_account(BlockchainType blockchain_type,
-            const ExtendedKey& master_key, uint32_t index) override;
-    AccountPtr make_account(BlockchainType blockchain_type, const char* serialized_private_key) override;
+    HDAccountPtr make_hd_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
+            const ExtendedKey& master_key,
+            uint32_t index) override;
+
+    AccountPtr make_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
+            const char* serialized_private_key) override;
+
     TransactionPtr make_transaction(const Account&) override;
     void validate_address(BlockchainType blockchain_type, const char*) override;
 };

--- a/multy_core/src/bitcoin/bitcoin_key.cpp
+++ b/multy_core/src/bitcoin/bitcoin_key.cpp
@@ -1,0 +1,218 @@
+/* Copyright 2018 by Multy.io
+ * Licensed under Multy.io license.
+ *
+ * See LICENSE for details
+ */
+
+#include "multy_core/src/bitcoin/bitcoin_key.h"
+
+#include "multy_core/src/exception.h"
+#include "multy_core/src/exception_stream.h"
+#include "multy_core/src/utility.h"
+#include "multy_core/src/hash.h"
+
+#include "wally_crypto.h"
+
+#include <cstring>
+
+namespace
+{
+using namespace multy_core::internal;
+
+const uint8_t PRIVATE_KEY_EXPORT_PREFIXES[2] = {
+    // Main net:
+    0x80,
+    // Test net:
+    0xEF
+};
+
+const uint8_t WIF_COMPRESSED_PUBLIC_KEY_SUFFIX = 0x01;
+
+uint8_t get_private_key_prefix(BitcoinNetType net_type)
+{
+    assert(net_type < array_size(PRIVATE_KEY_EXPORT_PREFIXES));
+    return PRIVATE_KEY_EXPORT_PREFIXES[net_type];
+}
+
+} // namespace
+
+namespace multy_core
+{
+namespace internal
+{
+
+BitcoinPublicKey::BitcoinPublicKey(KeyData key_data)
+    : m_data(std::move(key_data))
+{
+}
+
+BitcoinPublicKey::~BitcoinPublicKey()
+{}
+
+std::string BitcoinPublicKey::to_string() const
+{
+    CharPtr out_str;
+    THROW_IF_WALLY_ERROR(
+            wally_base58_from_bytes(
+                    m_data.data(), m_data.size(), 0, reset_sp(out_str)),
+            "Failed to serialize Bitcoin public key.");
+    return std::string(out_str.get());
+}
+
+const BinaryData BitcoinPublicKey::get_content() const
+{
+    return as_binary_data(m_data);
+}
+
+PublicKeyPtr BitcoinPublicKey::clone() const
+{
+    return make_clone(*this);
+}
+
+
+BitcoinPrivateKey::BitcoinPrivateKey(KeyData data,
+        BitcoinNetType net_type,
+        PublicKeyFormat public_key_format)
+    : m_data(std::move(data)),
+      m_net_type(net_type),
+      m_public_key_format(public_key_format)
+{
+    ec_validate_private_key(as_binary_data(m_data));
+}
+
+BitcoinPrivateKey::BitcoinPrivateKey(const BinaryData& data,
+        BitcoinNetType net_type,
+        PublicKeyFormat public_key_format)
+    : m_data(data.data, data.data + data.len),
+      m_net_type(net_type),
+      m_public_key_format(public_key_format)
+{
+    ec_validate_private_key(as_binary_data(m_data));
+}
+
+BitcoinPrivateKey::~BitcoinPrivateKey()
+{}
+
+std::string BitcoinPrivateKey::to_string() const
+{
+    KeyData data(m_data);
+    data.insert(data.begin(), get_private_key_prefix(m_net_type));
+    if (m_public_key_format == EC_PUBLIC_KEY_COMPRESSED)
+    {
+        data.push_back(WIF_COMPRESSED_PUBLIC_KEY_SUFFIX);
+    }
+
+    CharPtr out_str;
+    THROW_IF_WALLY_ERROR(
+            wally_base58_from_bytes(
+                    data.data(), data.size(),
+                    BASE58_FLAG_CHECKSUM,
+                    reset_sp(out_str)),
+            "Failed to serialize Bitcoin private key.");
+    wally_bzero(data.data(), data.size());
+
+    return std::string(out_str.get());
+}
+
+PublicKeyPtr BitcoinPrivateKey::make_public_key() const
+{
+    const size_t public_key_size =
+            (m_public_key_format == EC_PUBLIC_KEY_COMPRESSED)
+                    ? EC_PUBLIC_KEY_LEN : EC_PUBLIC_KEY_UNCOMPRESSED_LEN;
+    BitcoinPublicKey::KeyData key_data(public_key_size, 0);
+    BinaryData public_key_data = as_binary_data(key_data);
+
+    ec_private_to_public_key(as_binary_data(m_data),
+            m_public_key_format,
+            &public_key_data);
+
+    return PublicKeyPtr(new BitcoinPublicKey(key_data));
+}
+
+PrivateKeyPtr BitcoinPrivateKey::clone() const
+{
+    return make_clone(*this);
+}
+
+BinaryDataPtr BitcoinPrivateKey::sign(const BinaryData& data) const
+{
+    auto data_hash = do_hash<SHA2_DOUBLE, 256>(data);
+
+    std::array<uint8_t, EC_SIGNATURE_LEN> signature;
+    THROW_IF_WALLY_ERROR(
+            wally_ec_sig_from_bytes(
+                    m_data.data(), m_data.size(),
+                    data_hash.data(), data_hash.size(),
+                    EC_FLAG_ECDSA, signature.data(), signature.size()),
+            "Failed to sign binary data with private key.");
+    wally_bzero(data_hash.data(), data_hash.size());
+
+    std::array<uint8_t, EC_SIGNATURE_DER_MAX_LEN> der_signature;
+    size_t written;
+    THROW_IF_WALLY_ERROR(
+            wally_ec_sig_to_der(
+                    signature.data(), signature.size(),
+                    der_signature.data(), der_signature.size(), &written),
+            "Failed to convert signature to DER format.");
+    wally_bzero(signature.data(), signature.size());
+
+    return make_clone(BinaryData{der_signature.data(), written});
+}
+
+BitcoinNetType BitcoinPrivateKey::get_net_type() const
+{
+    return m_net_type;
+}
+
+BitcoinPrivateKeyPtr make_bitcoin_private_key_from_wif(const char* wif_string)
+{
+    INVARIANT(wif_string != nullptr);
+
+    size_t resulting_size = 0;
+    THROW_IF_WALLY_ERROR(
+            wally_base58_get_length(wif_string, &resulting_size),
+            "Faield to process base-58 encoded private key.");
+
+    std::vector<unsigned char> key_data(resulting_size, 0);
+
+    THROW_IF_WALLY_ERROR(
+            wally_base58_to_bytes(
+                    wif_string, BASE58_FLAG_CHECKSUM, key_data.data(),
+                    key_data.size(), &resulting_size),
+            "Faield to deserialize base-58 encoded private key.");
+
+    if (resulting_size > key_data.size() || resulting_size < EC_PRIVATE_KEY_LEN)
+    {
+        THROW_EXCEPTION("Failed to deserialize private key.");
+    }
+    key_data.resize(resulting_size);
+
+    BitcoinNetType net_type = BITCOIN_NET_TYPE_MAINNET;
+    // WIF, drop first 0x80 byte
+    if (key_data[0] == 0x80 || key_data[0] == 0xef)
+    {
+        net_type = (key_data[0] == 0xef) ? BITCOIN_NET_TYPE_TESTNET : BITCOIN_NET_TYPE_MAINNET;
+        key_data.erase(key_data.begin());
+    }
+    bool use_compressed_public_key = false;
+    // WIF, drop last 0x01 byte
+    const char* compressed_pefixes = net_type == BITCOIN_NET_TYPE_MAINNET ? "LK" : "c";
+    if (strchr(compressed_pefixes, wif_string[0])
+            && key_data.back() == WIF_COMPRESSED_PUBLIC_KEY_SUFFIX)
+    {
+        key_data.erase(key_data.end() - 1);
+        use_compressed_public_key = true;
+    }
+
+    THROW_IF_WALLY_ERROR(
+            wally_ec_private_key_verify(key_data.data(), key_data.size()),
+            "Failed to verify private key.");
+
+    return BitcoinPrivateKeyPtr(new BitcoinPrivateKey(
+            std::move(key_data),
+            net_type,
+            (use_compressed_public_key ? EC_PUBLIC_KEY_COMPRESSED : EC_PUBLIC_KEY_UNCOMPRESSED)));
+}
+
+} // namespace internal
+} // namespace multy_core

--- a/multy_core/src/bitcoin/bitcoin_key.h
+++ b/multy_core/src/bitcoin/bitcoin_key.h
@@ -1,0 +1,78 @@
+/* Copyright 2018 by Multy.io
+ * Licensed under Multy.io license.
+ *
+ * See LICENSE for details
+ */
+
+#ifndef MULTY_CORE_BITCOIN_KEY_H
+#define MULTY_CORE_BITCOIN_KEY_H
+
+#include "multy_core/bitcoin.h"
+
+#include "multy_core/src/api/key_impl.h"
+#include "multy_core/src/ec_key_utils.h"
+
+struct BinaryData;
+
+#include <vector>
+#include <cstdint>
+#include <string>
+
+namespace multy_core
+{
+namespace internal
+{
+
+struct BitcoinPrivateKey;
+typedef UPtr<BitcoinPrivateKey> BitcoinPrivateKeyPtr;
+
+struct BitcoinPublicKey : public PublicKey
+{
+public:
+    typedef std::vector<uint8_t> KeyData;
+
+    explicit BitcoinPublicKey(KeyData key_data);
+    ~BitcoinPublicKey();
+
+    std::string to_string() const override;
+    const BinaryData get_content() const override;
+    PublicKeyPtr clone() const override;
+
+private:
+    const KeyData m_data;
+};
+
+struct BitcoinPrivateKey : public PrivateKey
+{
+    typedef std::vector<uint8_t> KeyData;
+
+    BitcoinPrivateKey(KeyData data,
+            BitcoinNetType net_type,
+            PublicKeyFormat public_key_format);
+
+    BitcoinPrivateKey(const BinaryData& data,
+            BitcoinNetType net_type,
+            PublicKeyFormat public_key_format);
+    ~BitcoinPrivateKey();
+
+    std::string to_string() const override;
+    PublicKeyPtr make_public_key() const override;
+    PrivateKeyPtr clone() const override;
+    BinaryDataPtr sign(const BinaryData& data) const override;
+
+    BitcoinNetType get_net_type() const;
+
+private:
+    // TODO: use a shared_pointer to KeyData here to keep a single copy of
+    // the private key data in memory.
+    const KeyData m_data;    // private key data with no prefix
+    const BitcoinNetType m_net_type;
+    const PublicKeyFormat m_public_key_format;
+};
+
+BitcoinPrivateKeyPtr make_bitcoin_private_key_from_wif(const char* wif_string);
+
+} // namespace internal
+} // namespace multy_core
+
+#endif // MULTY_CORE_BITCOIN_KEY_H

--- a/multy_core/src/bitcoin/bitcoin_transaction.cpp
+++ b/multy_core/src/bitcoin/bitcoin_transaction.cpp
@@ -718,7 +718,11 @@ void BitcoinTransaction::verify() const
 
         if (*sig_script != **s->prev_transaction_out_script_pubkey)
         {
-            AccountPtr error_account = make_bitcoin_account(s->private_key->to_string().c_str());
+            AccountPtr error_account = make_bitcoin_account(
+                    s->private_key->to_string().c_str(),
+                    // TODO: get account type from initial account, and put it here.
+                    BITCOIN_ACCOUNT_DEFAULT);
+
             THROW_EXCEPTION2(ERROR_TRANSACTION_INVALID_PRIVATE_KEY,
                     "Source can't be spent using given private key.")
                     << " Source index: " << source_index

--- a/multy_core/src/blockchain_facade_base.h
+++ b/multy_core/src/blockchain_facade_base.h
@@ -31,10 +31,13 @@ public:
 
     virtual HDAccountPtr make_hd_account(
             BlockchainType blockchain_type,
+            uint32_t account_type,
             const ExtendedKey& master_key,
             uint32_t index) = 0;
 
-    virtual AccountPtr make_account(BlockchainType,
+    virtual AccountPtr make_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
             const char* serialized_private_key) = 0;
 
     virtual TransactionPtr make_transaction(const Account&) = 0;

--- a/multy_core/src/ethereum/ethereum_facade.cpp
+++ b/multy_core/src/ethereum/ethereum_facade.cpp
@@ -6,9 +6,26 @@
 
 #include "multy_core/src/ethereum/ethereum_facade.h"
 
-#include "multy_core/src/exception.h"
 #include "multy_core/src/ethereum/ethereum_account.h"
 #include "multy_core/src/ethereum/ethereum_transaction.h"
+
+#include "multy_core/src/exception.h"
+#include "multy_core/src/exception_stream.h"
+
+namespace
+{
+
+void validate_ethereum_account_type(uint32_t account_type)
+{
+    if (account_type != 0)
+    {
+        THROW_EXCEPTION2(ERROR_INVALID_ARGUMENT,
+                "Unknown Ethereum account type.")
+                << " Value: " << account_type << ".";
+    }
+}
+
+} // namespace
 
 namespace multy_core
 {
@@ -25,15 +42,22 @@ EthereumFacade::~EthereumFacade()
 
 HDAccountPtr EthereumFacade::make_hd_account(
         BlockchainType blockchain_type,
+        uint32_t account_type,
         const ExtendedKey& master_key,
         uint32_t index)
 {
+    validate_ethereum_account_type(account_type);
+
     return HDAccountPtr(new EthereumHDAccount(blockchain_type, master_key, index));
 }
 
-AccountPtr EthereumFacade::make_account(BlockchainType blockchain_type,
+AccountPtr EthereumFacade::make_account(
+        BlockchainType blockchain_type,
+        uint32_t account_type,
         const char* serialized_private_key)
 {
+    validate_ethereum_account_type(account_type);
+
     return make_ethereum_account(blockchain_type, serialized_private_key);
 }
 

--- a/multy_core/src/ethereum/ethereum_facade.h
+++ b/multy_core/src/ethereum/ethereum_facade.h
@@ -20,10 +20,17 @@ public:
     EthereumFacade();
     ~EthereumFacade();
 
-    HDAccountPtr make_hd_account(BlockchainType blockchain_type,
-            const ExtendedKey& master_key, uint32_t index) override;
-    AccountPtr make_account(BlockchainType blockchain_type,
+    HDAccountPtr make_hd_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
+            const ExtendedKey& master_key,
+            uint32_t index) override;
+
+    AccountPtr make_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
             const char* serialized_private_key) override;
+
     TransactionPtr make_transaction(const Account&) override;
     void validate_address(BlockchainType blockchain_type,
             const char* address) override;

--- a/multy_core/src/golos/golos_facade.cpp
+++ b/multy_core/src/golos/golos_facade.cpp
@@ -17,6 +17,21 @@
 #include <cstring>
 #include <regex>
 
+namespace
+{
+
+void validate_golos_account_type(uint32_t account_type)
+{
+    if (account_type != 0)
+    {
+        THROW_EXCEPTION2(ERROR_INVALID_ARGUMENT,
+                "Unknown Golos account type.")
+                << " Value: " << account_type << ".";
+    }
+}
+
+} // namespace
+
 namespace multy_core
 {
 namespace internal
@@ -32,15 +47,22 @@ GolosFacade::~GolosFacade()
 
 HDAccountPtr GolosFacade::make_hd_account(
         BlockchainType blockchain_type,
+        uint32_t account_type,
         const ExtendedKey& master_key,
         uint32_t index)
 {
+    validate_golos_account_type(account_type);
+
     return HDAccountPtr(new GolosHDAccount(blockchain_type, master_key, index));
 }
 
-AccountPtr GolosFacade::make_account(BlockchainType blockchain_type,
+AccountPtr GolosFacade::make_account(
+        BlockchainType blockchain_type,
+        uint32_t account_type,
         const char* serialized_private_key)
 {
+    validate_golos_account_type(account_type);
+
     return make_golos_account(blockchain_type, serialized_private_key);
 }
 

--- a/multy_core/src/golos/golos_facade.h
+++ b/multy_core/src/golos/golos_facade.h
@@ -20,9 +20,17 @@ public:
     GolosFacade();
     ~GolosFacade();
 
-    HDAccountPtr make_hd_account(BlockchainType blockchain_type,
-            const ExtendedKey& master_key, uint32_t index) override;
-    AccountPtr make_account(BlockchainType blockchain_type, const char* serialized_private_key) override;
+    HDAccountPtr make_hd_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
+            const ExtendedKey& master_key,
+            uint32_t index) override;
+
+    AccountPtr make_account(
+            BlockchainType blockchain_type,
+            uint32_t account_type,
+            const char* serialized_private_key) override;
+
     TransactionPtr make_transaction(const Account&) override;
     void validate_address(BlockchainType blockchain_type, const char*) override;
 };

--- a/multy_test/serialized_keys_test_base.cpp
+++ b/multy_test/serialized_keys_test_base.cpp
@@ -34,18 +34,20 @@ void PrintTo(const SerializedKeyTestCase& c, std::ostream* out)
 void SerializedKeyTestP::SetUp()
 {
     const BlockchainType blockchain_type = ::testing::get<0>(GetParam());
-    const SerializedKeyTestCase& test_data = ::testing::get<1>(GetParam());
+    const uint32_t account_type = ::testing::get<1>(GetParam());
+    const SerializedKeyTestCase& test_data = ::testing::get<2>(GetParam());
 
     HANDLE_ERROR(
             make_account(
                     blockchain_type,
+                    account_type,
                     test_data.private_key, reset_sp(account)));
     ASSERT_NE(nullptr, account);
 }
 
 TEST_P(SerializedKeyTestP, public_key)
 {
-    const SerializedKeyTestCase& test_data = ::testing::get<1>(GetParam());
+    const SerializedKeyTestCase& test_data = ::testing::get<2>(GetParam());
 
     ConstCharPtr public_key_string;
     KeyPtr public_key;
@@ -63,7 +65,7 @@ TEST_P(SerializedKeyTestP, public_key)
 
 TEST_P(SerializedKeyTestP, address)
 {
-    const SerializedKeyTestCase& test_data = ::testing::get<1>(GetParam());
+    const SerializedKeyTestCase& test_data = ::testing::get<2>(GetParam());
     if (!test_data.address || strlen(test_data.address) == 0)
     {
         ASSERT_FALSE(blockchain_can_derive_address_from_private_key(
@@ -79,7 +81,7 @@ TEST_P(SerializedKeyTestP, address)
 
 TEST_P(SerializedKeyTestP, private_key)
 {
-    const SerializedKeyTestCase& test_data = ::testing::get<1>(GetParam());
+    const SerializedKeyTestCase& test_data = ::testing::get<2>(GetParam());
 
     KeyPtr private_key;
     HANDLE_ERROR(

--- a/multy_test/serialized_keys_test_base.h
+++ b/multy_test/serialized_keys_test_base.h
@@ -24,7 +24,7 @@ struct SerializedKeyTestCase
 void PrintTo(const SerializedKeyTestCase& c, std::ostream* out);
 
 class SerializedKeyTestP : public ::testing::TestWithParam<
-        ::testing::tuple<BlockchainType, SerializedKeyTestCase>>
+        ::testing::tuple<BlockchainType, uint32_t, SerializedKeyTestCase>>
 {
     void SetUp() override;
 

--- a/multy_test/smoke_test.cpp
+++ b/multy_test/smoke_test.cpp
@@ -62,7 +62,10 @@ TEST_P(AccountSmokeTestP, AccountFromEntropy)
     HDAccountPtr root_account;
     HANDLE_ERROR(
             make_hd_account(
-                    root_key.get(), expected_blockchain, 0,
+                    root_key.get(),
+                    expected_blockchain,
+                    BITCOIN_ACCOUNT_DEFAULT,
+                    0,
                     reset_sp(root_account)));
     ASSERT_NE(nullptr, root_account);
 

--- a/multy_test/test_bitcoin_account.cpp
+++ b/multy_test/test_bitcoin_account.cpp
@@ -150,6 +150,7 @@ INSTANTIATE_TEST_CASE_P(
         SerializedKeyTestP,
         ::testing::Combine(
                 ::testing::Values(BITCOIN_MAIN_NET),
+                ::testing::Values(BITCOIN_ACCOUNT_P2PKH),
                 ::testing::ValuesIn(TEST_CASES)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -225,11 +226,11 @@ TEST_P(BitcoinTestSign, SignWithPrivateKey)
     const char* message_data = GetParam().message;
 
     AccountPtr account;
-    ErrorPtr error;
-    error.reset(
-            make_account(
-                    BITCOIN_MAIN_NET, private_key_data, reset_sp(account)));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(make_account(
+            BITCOIN_MAIN_NET,
+            BITCOIN_ACCOUNT_P2PKH,
+            private_key_data,
+            reset_sp(account)));
     ASSERT_NE(nullptr, account);
 
     PrivateKeyPtr private_key = account->get_private_key();

--- a/multy_test/test_bitcoin_transaction.cpp
+++ b/multy_test/test_bitcoin_transaction.cpp
@@ -45,8 +45,12 @@ AccountPtr make_account(
         const char* serialized_private_key)
 {
     AccountPtr account;
-    throw_if_error(
-            make_account(blockchain, serialized_private_key, reset_sp(account)));
+    throw_if_error(make_account(
+            blockchain,
+            BITCOIN_ACCOUNT_DEFAULT,
+            serialized_private_key,
+            reset_sp(account)));
+
     return account;
 }
 
@@ -272,6 +276,7 @@ GTEST_TEST(BitcoinTransactionTest, create_raw_transaction_public_api)
     AccountPtr account;
     HANDLE_ERROR(make_account(
             BITCOIN_TEST_NET,
+            BITCOIN_ACCOUNT_P2PKH,
             "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
             reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -346,6 +351,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet)
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -401,6 +407,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_explicit_change)
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -481,6 +488,7 @@ GTEST_TEST(BitcoinTransactionTest, Unprofitable_change)
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -563,6 +571,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet2)
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -620,6 +629,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet2_with_key_to_source)
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -685,6 +695,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet3)
 
     HANDLE_ERROR(make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -753,6 +764,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_with_many_input_from_one_addreses_t
     AccountPtr account;
     HANDLE_ERROR(make_account(
                     BITCOIN_TEST_NET,
+                     BITCOIN_ACCOUNT_P2PKH,
                     "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -827,6 +839,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_with_many_input_from_different_addr
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cScuLx5taDyuAfCnin5WWZz65yGCHMuuaFv6mgearmqAHC4p53sz",
                     reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -835,6 +848,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_with_many_input_from_different_addr
     HANDLE_ERROR(
             make_account(
                     BITCOIN_TEST_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "cVbMJKcfEGi4wgsN39rMPkYVAaLeRaPPbrPpJfcH9B9dZCPbS7kT",
                     reset_sp(account1)));
     ASSERT_NE(nullptr, account1);
@@ -1090,6 +1104,7 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_mainnet_with_op_return)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                     BITCOIN_MAIN_NET,
+                    BITCOIN_ACCOUNT_P2PKH,
                     "5KWNESNNyn68focSAoUm3zrgnGZ4fABoWf9DccbEUHwWFhx5ouj",
                     reset_sp(account)));
     const PrivateKeyPtr private_key = account->get_private_key();

--- a/multy_test/test_deletion.cpp
+++ b/multy_test/test_deletion.cpp
@@ -31,9 +31,12 @@ class DeletionTestP : public ::testing::TestWithParam<BlockchainType>
 public:
     void SetUp()
     {
-        HANDLE_ERROR(
-                make_hd_account(
-                        &master_key, GetParam(), 0, reset_sp(hd_account)));
+        HANDLE_ERROR(make_hd_account(
+                &master_key,
+                GetParam(),
+                ACCOUNT_TYPE_DEFAULT,
+                0,
+                reset_sp(hd_account)));
 
         HANDLE_ERROR(
                 make_hd_leaf_account(

--- a/multy_test/test_ethereum_account.cpp
+++ b/multy_test/test_ethereum_account.cpp
@@ -127,6 +127,7 @@ INSTANTIATE_TEST_CASE_P(
                         BlockchainType{BLOCKCHAIN_ETHEREUM, ETHEREUM_CHAIN_ID_MAINNET},
                         BlockchainType{BLOCKCHAIN_ETHEREUM, ETHEREUM_CHAIN_ID_RINKEBY}
                 ),
+                ::testing::Values(ACCOUNT_TYPE_DEFAULT),
                 ::testing::ValuesIn(TEST_CASES)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -154,7 +155,11 @@ GTEST_TEST(EtheremAccountTest, PrivateKeySig)
     const char MESSAGE[] = "msg";
 
     AccountPtr account;
-    HANDLE_ERROR(make_account(ETHEREUM_MAIN_NET, PRIVATE_KEY, reset_sp(account)));
+    HANDLE_ERROR(make_account(
+            ETHEREUM_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            PRIVATE_KEY,
+            reset_sp(account)));
 
     BinaryDataPtr message;
     HANDLE_ERROR(make_binary_data_from_bytes(

--- a/multy_test/test_ethereum_transaction.cpp
+++ b/multy_test/test_ethereum_transaction.cpp
@@ -38,6 +38,7 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_public_api)
 
     HANDLE_ERROR(make_account(
                      ETHEREUM_TEST_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "5a37680b86fabdec299fa02bdfba8c9dfad08d796dc58c1d07527a751905bf71",
                      reset_sp(account)));
 
@@ -105,6 +106,7 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet1)
 
     HANDLE_ERROR(make_account(
                      ETHEREUM_TEST_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "5a37680b86fabdec299fa02bdfba8c9dfad08d796dc58c1d07527a751905bf71",
                      reset_sp(account)));
 
@@ -150,6 +152,7 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet2)
 
     HANDLE_ERROR(make_account(
                      ETHEREUM_TEST_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "5a37680b86fabdec299fa02bdfba8c9dfad08d796dc58c1d07527a751905bf71",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -202,6 +205,7 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet_withdata)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                      ETHEREUM_TEST_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "5a37680b86fabdec299fa02bdfba8c9dfad08d796dc58c1d07527a751905bf71",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -258,6 +262,7 @@ GTEST_TEST(EthereumTransactionTest, transaction_update_empty_tx)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                      ETHEREUM_TEST_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "5a37680b86fabdec299fa02bdfba8c9dfad08d796dc58c1d07527a751905bf71",
                      reset_sp(account)));
 
@@ -289,6 +294,7 @@ GTEST_TEST(EthereumTransactionTest, transaction_get_total_spent)
     AccountPtr account;
     HANDLE_ERROR(make_account(
             ETHEREUM_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
             "5a37680b86fabdec299fa02bdfba8c9dfad08d796dc58c1d07527a751905bf71",
             reset_sp(account)));
 
@@ -336,6 +342,7 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_mainnet)
 
     HANDLE_ERROR(make_account(
                      ETHEREUM_MAIN_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "b81b3c491e397cbb4939787a81bd049d7a8c5ee819fd4e03afdab94813b06a00",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -385,6 +392,7 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_mainnet_withdata)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                      ETHEREUM_MAIN_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "b81b3c491e397cbb4939787a81bd049d7a8c5ee819fd4e03afdab94813b06a00",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -438,6 +446,7 @@ GTEST_TEST(EthereumTransactionTest, DISABLED_SmokeTest_testnet_ERC20_transfer)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                      ETHEREUM_MAIN_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "c8aea1b4d991e2bb7c17b1cb8b8dbda9fb59717df552e98ec3aca80410565a9f",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -490,6 +499,7 @@ GTEST_TEST(EthereumTransactionTest, DISABLED_SmokeTest_testnet_ERC20_transfer_2)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                      ETHEREUM_MAIN_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "0xb81b3c491e397cbb4939787a81bd049d7a8c5ee819fd4e03afdab94813b06a00",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);
@@ -541,6 +551,7 @@ GTEST_TEST(EthereumTransactionTest, token_transfer_API)
     AccountPtr account;
     HANDLE_ERROR(make_account(
                      ETHEREUM_MAIN_NET,
+                     ACCOUNT_TYPE_DEFAULT,
                      "b81b3c491e397cbb4939787a81bd049d7a8c5ee819fd4e03afdab94813b06a00",
                      reset_sp(account)));
     ASSERT_NE(nullptr, account);

--- a/multy_test/test_golos_account.cpp
+++ b/multy_test/test_golos_account.cpp
@@ -115,12 +115,18 @@ INSTANTIATE_TEST_CASE_P(
         SerializedKeyTestP,
         ::testing::Combine(
                 ::testing::Values(GOLOS_MAIN_NET),
+                ::testing::Values(ACCOUNT_TYPE_DEFAULT),
                 ::testing::ValuesIn(GOLOS_KEYS)));
 
 GTEST_TEST(GolosTest, private_key_sign)
 {
     AccountPtr account;
-    make_account(GOLOS_MAIN_NET, "5Hq2ZdSGZokcgLoNxNGL5kHKi4e3kUUCqorgFK6T6ka7KtSvYLj", reset_sp(account));
+    HANDLE_ERROR(make_account(
+            GOLOS_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "5Hq2ZdSGZokcgLoNxNGL5kHKi4e3kUUCqorgFK6T6ka7KtSvYLj",
+            reset_sp(account)));
+
     PrivateKeyPtr prv_key =  account->get_private_key();
     // binary serialize TX to sign golos private key
     BinaryDataPtr signature = prv_key->sign(as_binary_data(from_hex("782a3039b478c839e4cb0c941ff4eaeb7df40bdd68bd441afd444b9da763de1269466c1944189"

--- a/multy_test/test_golos_transaction.cpp
+++ b/multy_test/test_golos_transaction.cpp
@@ -35,7 +35,9 @@ using namespace test_utility;
 GTEST_TEST(GolosTransactionTest, DISABLED_SmokeTest_public_api)
 {
     AccountPtr account;
-    HANDLE_ERROR(make_account(GOLOS_MAIN_NET,
+    HANDLE_ERROR(make_account(
+            GOLOS_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
             "5JpDgood17pE47zB6pDJixg9Sw47QiHcQ9qCc3MeKYoYzRiMcnF",
             reset_sp(account)));
 
@@ -108,7 +110,9 @@ GTEST_TEST(GolosTransactionTest, DISABLED_SmokeTest_public_api)
 GTEST_TEST(GolosTransactionTest, DISABLED_SmokeTest_public_apis)
 {
     AccountPtr account;
-    HANDLE_ERROR(make_account(GOLOS_MAIN_NET,
+    HANDLE_ERROR(make_account(
+            GOLOS_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
             "5JpDgood17pE47zB6pDJixg9Sw47QiHcQ9qCc3MeKYoYzRiMcnF",
             reset_sp(account)));
 
@@ -182,7 +186,9 @@ GTEST_TEST(GolosTransactionTest, DISABLED_SmokeTest_public_apis)
 GTEST_TEST(GolosTransactionTest, DISABLED_SmokeTest_public_api_with_message)
 {
     AccountPtr account;
-    HANDLE_ERROR(make_account(GOLOS_MAIN_NET,
+    HANDLE_ERROR(make_account(
+            GOLOS_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
             "5JpDgood17pE47zB6pDJixg9Sw47QiHcQ9qCc3MeKYoYzRiMcnF",
             reset_sp(account)));
 

--- a/multy_test/test_properties.cpp
+++ b/multy_test/test_properties.cpp
@@ -157,6 +157,7 @@ GTEST_TEST(PropertiesTestInvalidArgs, properties_set_private_key_value)
     AccountPtr account1;
     HANDLE_ERROR(make_account(
             BITCOIN_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
             "cScuLx5taDyuAfCnin5WWZz65yGCHMuuaFv6mgearmqAHC4p53sz",
             reset_sp(account1)));
 
@@ -257,11 +258,11 @@ GTEST_TEST(PropertiesTestInvalidType, int32_properties)
             make_clone(BinaryData{data_4_vals, 4}));
 
     AccountPtr account;
-    error.reset(
-            make_account(
-                    BITCOIN_TEST_NET,
-                    "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
-                    reset_sp(account)));
+    HANDLE_ERROR(make_account(
+            BITCOIN_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
+            reset_sp(account)));
 
     const PrivateKeyPtr priv_key_property = account->get_private_key();
 
@@ -301,11 +302,11 @@ GTEST_TEST(PropertiesTestInvalidType, String_properties)
             make_clone(BinaryData{data_4_vals, 4}));
 
     AccountPtr account;
-    error.reset(
-            make_account(
-                    BITCOIN_TEST_NET,
-                    "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
-                    reset_sp(account)));
+    HANDLE_ERROR(make_account(
+            BITCOIN_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
+            reset_sp(account)));
 
     const PrivateKeyPtr priv_key_property = account->get_private_key();
 
@@ -345,11 +346,11 @@ GTEST_TEST(PropertiesTestInvalidType, Amount_properties)
             make_clone(BinaryData{data_4_vals, 4}));
 
     AccountPtr account;
-    error.reset(
-            make_account(
-                    BITCOIN_TEST_NET,
-                    "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
-                    reset_sp(account)));
+    HANDLE_ERROR(make_account(
+            BITCOIN_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
+            reset_sp(account)));
 
     const PrivateKeyPtr priv_key_property = account->get_private_key();
 
@@ -390,11 +391,11 @@ GTEST_TEST(PropertiesTestInvalidType, BinaryData_properties)
             make_clone(BinaryData{data_4_vals, 4}));
 
     AccountPtr account;
-    error.reset(
-            make_account(
-                    BITCOIN_TEST_NET,
-                    "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
-                    reset_sp(account)));
+    HANDLE_ERROR(make_account(
+            BITCOIN_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "cQeGKosJjWPn9GkB7QmvmotmBbVg1hm8UjdN6yLXEWZ5HAcRwam7",
+            reset_sp(account)));
 
     const PrivateKeyPtr priv_key_property = account->get_private_key();
 
@@ -528,11 +529,12 @@ GTEST_TEST(PropertiesTest, properties_set_private_key_value)
     PrivateKeyPtr priv_key_property;
 
     AccountPtr account1;
-    error.reset(
-            make_account(
-                    BITCOIN_TEST_NET,
-                    "cScuLx5taDyuAfCnin5WWZz65yGCHMuuaFv6mgearmqAHC4p53sz",
-                    reset_sp(account1)));
+    HANDLE_ERROR(make_account(
+            BITCOIN_TEST_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "cScuLx5taDyuAfCnin5WWZz65yGCHMuuaFv6mgearmqAHC4p53sz",
+            reset_sp(account1)));
+
     const PrivateKeyPtr priv_key_property1 = account1->get_private_key();
 
     properties.bind_property("v", &priv_key_property);

--- a/multy_test/test_transaction.cpp
+++ b/multy_test/test_transaction.cpp
@@ -31,9 +31,10 @@ GTEST_TEST(TransactionTestInvalidArgs, make_transaction)
     TransactionPtr transaction;
 
     HANDLE_ERROR(make_account(
-                    BITCOIN_MAIN_NET,
-                    "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj",
-                    reset_sp(account)));
+            BITCOIN_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj",
+            reset_sp(account)));
 
     EXPECT_ERROR(make_transaction(account.get(), nullptr));
 
@@ -147,11 +148,11 @@ GTEST_TEST(TransactionTest, make_transaction)
     AccountPtr account_transaction;
     TransactionPtr transaction;
 
-    HANDLE_ERROR(
-            make_account(
-                BITCOIN_MAIN_NET,
-                "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj",
-                reset_sp(account_transaction)));
+    HANDLE_ERROR(make_account(
+            BITCOIN_MAIN_NET,
+            ACCOUNT_TYPE_DEFAULT,
+            "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj",
+            reset_sp(account_transaction)));
 
     HANDLE_ERROR(make_transaction(account_transaction.get(), reset_sp(transaction)));
     EXPECT_NE(nullptr, transaction.get());


### PR DESCRIPTION
Additional account_type argument for following API methods:
 * make_account()
 * make_hd_account()
Added enum AccountType and Bitcoin-specific enum BitcoinAccountType;
Updated tests to match API update;
Minor refactoring: moved BitcoinPublicKey and BitcoinPrivateKey to bitcoin/key.h\.cpp