### PR TITLE
MUL-1033: Refactor test cases

### DIFF
--- a/multy_test/test_account.cpp
+++ b/multy_test/test_account.cpp
@@ -51,7 +51,6 @@ GTEST_TEST(AccountTest, fake_account)
     const char* EXPECTED_PATH_STRING = TEST_PATH_STRING;
     const BlockchainType EXPECTED_BLOCKCHAIN_TYPE = BITCOIN_MAIN_NET;
 
-    ErrorPtr error;
     TestHDAccount root_account(
             EXPECTED_BLOCKCHAIN_TYPE,
             EXPECTED_ADDRESS,
@@ -62,28 +61,25 @@ GTEST_TEST(AccountTest, fake_account)
     AccountPtr account;
     {
         ExtendedKeyPtr key;
-        error.reset(
+        HANDLE_ERROR(
                 make_hd_leaf_account(
                         &root_account, ADDRESS_EXTERNAL, 0, reset_sp(account)));
-        EXPECT_EQ(nullptr, error);
         ASSERT_NE(nullptr, account);
     }
 
     {
         ConstCharPtr address_str;
-        error.reset(
+        HANDLE_ERROR(
                 account_get_address_string(
                         account.get(), reset_sp(address_str)));
-        EXPECT_EQ(nullptr, error);
         ASSERT_NE(nullptr, address_str);
         ASSERT_STREQ(EXPECTED_ADDRESS, address_str.get());
     }
 
     {
         ConstCharPtr path_str;
-        error.reset(
+        HANDLE_ERROR(
                 account_get_address_path(account.get(), reset_sp(path_str)));
-        EXPECT_EQ(nullptr, error);
         ASSERT_NE(nullptr, path_str);
         ASSERT_STREQ(EXPECTED_PATH_STRING, path_str.get());
     }
@@ -91,8 +87,7 @@ GTEST_TEST(AccountTest, fake_account)
     {
         BlockchainType blockchain_type;
 
-        error.reset(account_get_blockchain_type(account.get(), &blockchain_type));
-        EXPECT_EQ(nullptr, error);
+        HANDLE_ERROR(account_get_blockchain_type(account.get(), &blockchain_type));
         ASSERT_EQ(EXPECTED_BLOCKCHAIN_TYPE, blockchain_type);
     }
 }
@@ -135,24 +130,19 @@ GTEST_TEST(AccountTestInvalidArgs, account_get_key)
             make_test_private_key(),
             make_test_public_key());
 
-    ErrorPtr error;
     KeyPtr key;
 
-    error.reset(account_get_key(nullptr, KEY_TYPE_PRIVATE, reset_sp(key)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_key(nullptr, KEY_TYPE_PRIVATE, reset_sp(key)));
     EXPECT_EQ(nullptr, key);
 
-    error.reset(account_get_key(&account, INVALID_KEY_TYPE, reset_sp(key)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_key(&account, INVALID_KEY_TYPE, reset_sp(key)));
     EXPECT_EQ(nullptr, key);
 
-    error.reset(account_get_key(&account, KEY_TYPE_PRIVATE, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_key(&account, KEY_TYPE_PRIVATE, nullptr));
 }
 
 GTEST_TEST(AccountTestInvalidArgs, account_get_address_string)
 {
-    ErrorPtr error;
     ConstCharPtr address_str;
 
     const TestAccount account(
@@ -160,17 +150,14 @@ GTEST_TEST(AccountTestInvalidArgs, account_get_address_string)
             TEST_ADDRESS, TEST_PATH, make_test_private_key(),
             make_test_public_key());
 
-    error.reset(account_get_address_string(nullptr, reset_sp(address_str)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_address_string(nullptr, reset_sp(address_str)));
     EXPECT_EQ(nullptr, address_str);
 
-    error.reset(account_get_address_string(&account, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_address_string(&account, nullptr));
 }
 
 GTEST_TEST(AccountTestInvalidArgs, account_get_address_path)
 {
-    ErrorPtr error;
     ConstCharPtr path_str;
 
     const TestAccount account(
@@ -178,17 +165,14 @@ GTEST_TEST(AccountTestInvalidArgs, account_get_address_path)
             TEST_ADDRESS, TEST_PATH, make_test_private_key(),
             make_test_public_key());
 
-    error.reset(account_get_address_path(nullptr, reset_sp(path_str)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_address_path(nullptr, reset_sp(path_str)));
     EXPECT_EQ(nullptr, path_str);
 
-    error.reset(account_get_address_path(&account, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_address_path(&account, nullptr));
 }
 
 GTEST_TEST(AccountTestInvalidArgs, account_get_blockchain)
 {
-    ErrorPtr error;
     BlockchainType blockchain_type = INVALID_BLOCKCHAIN_TYPE;
 
     const TestAccount account(
@@ -196,12 +180,10 @@ GTEST_TEST(AccountTestInvalidArgs, account_get_blockchain)
             TEST_ADDRESS, TEST_PATH, make_test_private_key(),
             make_test_public_key());
 
-    error.reset(account_get_blockchain_type(nullptr, &blockchain_type));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_blockchain_type(nullptr, &blockchain_type));
     EXPECT_EQ(INVALID_BLOCKCHAIN_TYPE, blockchain_type);
 
-    error.reset(account_get_blockchain_type(&account, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(account_get_blockchain_type(&account, nullptr));
 }
 
 GTEST_TEST(AccountTestInvalidArgs, validate_address)
@@ -237,7 +219,6 @@ TEST_P(AccountTestBlockchainSupportP, create_and_check_account_from_hd_account)
 {
     const ExtendedKey master_key = make_dummy_extended_key();
 
-    ErrorPtr error;
     HDAccountPtr root_account;
 
     HANDLE_ERROR(make_hd_account(
@@ -249,7 +230,7 @@ TEST_P(AccountTestBlockchainSupportP, create_and_check_account_from_hd_account)
     EXPECT_NE(nullptr, root_account);
 
     AccountPtr account;
-    error.reset(
+    HANDLE_ERROR(
             make_hd_leaf_account(
                     root_account.get(), ADDRESS_EXTERNAL, 0,
                     reset_sp(account)));
@@ -257,15 +238,14 @@ TEST_P(AccountTestBlockchainSupportP, create_and_check_account_from_hd_account)
     {
         BlockchainType actual_blockchain;
 
-        error.reset(account_get_blockchain_type(account.get(), &actual_blockchain));
-        EXPECT_EQ(nullptr, error);
+        HANDLE_ERROR(account_get_blockchain_type(account.get(), &actual_blockchain));
         EXPECT_EQ(GetParam(), actual_blockchain);
     }
 
     {
         ConstCharPtr address_str;
 
-        error.reset(
+        ErrorPtr error(
                 account_get_address_string(
                         account.get(), reset_sp(address_str)));
         if (blockchain_can_derive_address_from_private_key(GetParam().blockchain))
@@ -284,22 +264,19 @@ TEST_P(AccountTestBlockchainSupportP, create_and_check_account_from_hd_account)
     {
         ConstCharPtr path_str;
 
-        error.reset(
+        HANDLE_ERROR(
                 account_get_address_path(account.get(), reset_sp(path_str)));
-        EXPECT_EQ(nullptr, error);
         EXPECT_NE(nullptr, path_str);
         EXPECT_STRNE("", path_str.get());
     }
 
     {
         KeyPtr private_key;
-        error.reset(account_get_key(account.get(), KEY_TYPE_PRIVATE, reset_sp(private_key)));
-        EXPECT_EQ(nullptr, error);
+        HANDLE_ERROR(account_get_key(account.get(), KEY_TYPE_PRIVATE, reset_sp(private_key)));
         EXPECT_NE(nullptr, private_key);
 
         KeyPtr public_key;
-        error.reset(account_get_key(account.get(), KEY_TYPE_PUBLIC, reset_sp(public_key)));
-        EXPECT_EQ(nullptr, error);
+        HANDLE_ERROR(account_get_key(account.get(), KEY_TYPE_PUBLIC, reset_sp(public_key)));
         EXPECT_NE(nullptr, public_key);
 
         EXPECT_NE(public_key, private_key);

--- a/multy_test/test_big_int.cpp
+++ b/multy_test/test_big_int.cpp
@@ -599,15 +599,12 @@ GTEST_TEST(BigIntTest_Math, cmp_api)
 
 GTEST_TEST(BigIntTest_API_InvalidArgs, make_big_int)
 {
-    ErrorPtr error;
     BigIntPtr amount;
 
-    error.reset(make_big_int(nullptr, reset_sp(amount)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_big_int(nullptr, reset_sp(amount)));
     EXPECT_EQ(nullptr, amount);
 
-    error.reset(make_big_int("1", nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_big_int("1", nullptr));
 }
 
 GTEST_TEST(BigIntTest_API_InvalidArgs, make_big_int_clone)
@@ -623,74 +620,58 @@ GTEST_TEST(BigIntTest_API_InvalidArgs, make_big_int_clone)
 
 GTEST_TEST(BigIntTest_API_InvalidArgs, big_int_get_value)
 {
-    ErrorPtr error;
     BigInt amount(1);
     ConstCharPtr str;
 
-    error.reset(big_int_get_value(nullptr, reset_sp(str)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_get_value(nullptr, reset_sp(str)));
     EXPECT_EQ(nullptr, str);
 
-    error.reset(big_int_get_value(&amount, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_get_value(&amount, nullptr));
     EXPECT_EQ("1", amount);
 }
 
 GTEST_TEST(BigIntTest_API_InvalidArgs, big_int_set_value)
 {
-    ErrorPtr error;
     BigInt amount(1);
 
-    error.reset(big_int_set_value(nullptr, "1"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_set_value(nullptr, "1"));
 
-    error.reset(big_int_set_value(&amount, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_set_value(&amount, nullptr));
     EXPECT_EQ("1", amount);
 }
 
 
 GTEST_TEST(BigIntTest_API_InvalidValue, make_big_int)
 {
-    ErrorPtr error;
     BigIntPtr amount(new BigInt(1));
 
-    error.reset(make_big_int("foo",  reset_sp(amount)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_big_int("foo",  reset_sp(amount)));
     EXPECT_EQ("1", *amount);
 
-    error.reset(make_big_int("",  reset_sp(amount)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_big_int("",  reset_sp(amount)));
     EXPECT_EQ("1", *amount);
 
-    error.reset(make_big_int("1.1",  reset_sp(amount)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_big_int("1.1",  reset_sp(amount)));
     EXPECT_EQ("1", *amount);
 
-    error.reset(make_big_int(" ",  reset_sp(amount)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_big_int(" ",  reset_sp(amount)));
     EXPECT_EQ("1", *amount);
 }
 
 GTEST_TEST(BigIntTest_API_InvalidValue, big_int_set_value)
 {
-    ErrorPtr error;
     BigInt amount("1");
 
-    error.reset(big_int_set_value(&amount, "foo"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_set_value(&amount, "foo"));
     EXPECT_EQ("1", amount);
 
-    error.reset(big_int_set_value(&amount, "1.1"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_set_value(&amount, "1.1"));
     EXPECT_EQ("1", amount);
 
-    error.reset(big_int_set_value(&amount, " "));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_set_value(&amount, " "));
     EXPECT_EQ("1", amount);
 
-    error.reset(big_int_set_value(&amount, ""));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(big_int_set_value(&amount, ""));
     EXPECT_EQ("1", amount);
 }
 
@@ -717,11 +698,9 @@ GTEST_TEST(BigIntTest_API, big_int_set_int64_value)
 
 GTEST_TEST(BigIntTest_API, make_big_int)
 {
-    ErrorPtr error;
     BigIntPtr amount;
 
-    error.reset(make_big_int("1",  reset_sp(amount)));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(make_big_int("1",  reset_sp(amount)));
     EXPECT_EQ("1", *amount);
 }
 
@@ -736,23 +715,19 @@ GTEST_TEST(BigIntTest_API, make_big_int_clone)
 
 GTEST_TEST(BigIntTest_API, big_int_get_value)
 {
-    ErrorPtr error;
     BigInt amount(1);
     ConstCharPtr test_str;
 
-    error.reset(big_int_get_value(&amount, reset_sp(test_str)));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(big_int_get_value(&amount, reset_sp(test_str)));
     EXPECT_NE(nullptr, test_str);
     EXPECT_EQ("1", amount);
 }
 
 GTEST_TEST(BigIntTest_API, big_int_set_value)
 {
-    ErrorPtr error;
     BigInt amount(5);
 
-    error.reset(big_int_set_value(&amount, "1"));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(big_int_set_value(&amount, "1"));
     EXPECT_EQ("1", amount);
 }
 

--- a/multy_test/test_ethereum_transaction.cpp
+++ b/multy_test/test_ethereum_transaction.cpp
@@ -114,10 +114,10 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet1)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("7500000000000000000");
-    const BigInt value("1");
-    const BigInt gas_limit("21001");
-    const BigInt gas_price("1");
+    const BigInt balance(7.5_ETH);
+    const BigInt value(1_WEI);
+    const BigInt gas_limit(21001);
+    const BigInt gas_price(1_WEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();
@@ -161,10 +161,10 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet2)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("7500000000000000000");
-    const BigInt value("2305843009213693952");
-    const BigInt gas_limit("21001");
-    const BigInt gas_price("64424509440");
+    const BigInt balance(7.5_ETH);
+    const BigInt value(2305843009213693952_WEI);
+    const BigInt gas_limit(21001);
+    const BigInt gas_price(64424509440_WEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();
@@ -214,10 +214,10 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet_withdata)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("7500000000000000000");
-    const BigInt value("1000");
-    const BigInt gas_limit("121000");
-    const BigInt gas_price("3000000000000");
+    const BigInt balance(7.5_ETH);
+    const BigInt value(1000_WEI);
+    const BigInt gas_limit(121000);
+    const BigInt gas_price(3000.0_GWEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();
@@ -301,11 +301,10 @@ GTEST_TEST(EthereumTransactionTest, transaction_get_total_spent)
     TransactionPtr transaction;
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
 
-    const BigInt available(1000000);
-    const BigInt sent(10000);
-
-    const BigInt gas_limit("121000");
-    const BigInt gas_price("3000000000000");
+    const BigInt available(1000000_WEI);
+    const BigInt sent(10000_WEI);
+    const BigInt gas_limit(121000);
+    const BigInt gas_price(3000.0_GWEI);
 
     {
         Properties& source = transaction->add_source();
@@ -351,10 +350,10 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_mainnet)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("10000000000000000");
-    const BigInt value("2000000000000000");
+    const BigInt balance(0.01_ETH);
+    const BigInt value(0.002_ETH);
     const BigInt gas_limit(21001);
-    const BigInt gas_price("4000000000");
+    const BigInt gas_price(4.0_GWEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();
@@ -401,10 +400,10 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_mainnet_withdata)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("7916000000000000");
-    const BigInt value("2000000000000000");
+    const BigInt balance(0.007916_ETH);
+    const BigInt value(0.002_ETH);
     const BigInt gas_limit(121000);
-    const BigInt gas_price("4000000000");
+    const BigInt gas_price(4.0_GWEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();
@@ -455,10 +454,10 @@ GTEST_TEST(EthereumTransactionTest, DISABLED_SmokeTest_testnet_ERC20_transfer)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("100000000000000000");
-    const BigInt value("1000000000000000000");
+    const BigInt balance(0.1_ETH);
+    const BigInt value("1000000000000000000"); //token
     const BigInt gas_limit(153327);
-    const BigInt gas_price("1000000000");
+    const BigInt gas_price(1.0_GWEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();
@@ -508,10 +507,10 @@ GTEST_TEST(EthereumTransactionTest, DISABLED_SmokeTest_testnet_ERC20_transfer_2)
     HANDLE_ERROR(make_transaction(account.get(), reset_sp(transaction)));
     ASSERT_NE(nullptr, transaction);
 
-    const BigInt balance("100000000000000000");
+    const BigInt balance(0.1_ETH);
     const BigInt value("500000000000000000");
     const BigInt gas_limit(153327);
-    const BigInt gas_price("1000000000");
+    const BigInt gas_price(1.0_GWEI);
 
     {
         Properties& properties = transaction->get_transaction_properties();

--- a/multy_test/test_keys.cpp
+++ b/multy_test/test_keys.cpp
@@ -45,16 +45,13 @@ TEST_P(KeysTestValidCasesP, Test)
     const bytes seed_data = from_hex(param.seed);
     const BinaryData seed{seed_data.data(), seed_data.size()};
 
-    ErrorPtr error;
     ExtendedKeyPtr key;
     ConstCharPtr key_string;
 
-    error.reset(make_master_key(&seed, reset_sp(key)));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(make_master_key(&seed, reset_sp(key)));
     ASSERT_NE(nullptr, key);
 
-    error.reset(extended_key_to_string(key.get(), reset_sp(key_string)));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(extended_key_to_string(key.get(), reset_sp(key_string)));
     EXPECT_STREQ(param.root_key, key_string.get());
 }
 
@@ -63,19 +60,15 @@ GTEST_TEST(KeysTestInvalidArgs, make_master_key)
     const unsigned char data_vals[] = {1U, 2U, 3U, 4U};
     const BinaryData data{data_vals, 3};
 
-    ErrorPtr error;
     ExtendedKeyPtr key;
 
-    error.reset(make_master_key(nullptr, reset_sp(key)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_master_key(nullptr, reset_sp(key)));
     EXPECT_EQ(nullptr, key);
 
-    error.reset(make_master_key(&data, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_master_key(&data, nullptr));
 
     // Even though all arguments are present, data is still invalid
-    error.reset(make_master_key(&data, reset_sp(key)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_master_key(&data, reset_sp(key)));
     EXPECT_EQ(nullptr, key);
 }
 
@@ -83,14 +76,11 @@ GTEST_TEST(KeysTestInvalidArgs, make_child_key)
 {
     const ExtendedKey parent_key = make_dummy_extended_key();
 
-    ErrorPtr error;
     ExtendedKeyPtr child_key;
-    error.reset(make_child_key(nullptr, 0, reset_sp(child_key)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_child_key(nullptr, 0, reset_sp(child_key)));
     EXPECT_EQ(nullptr, child_key);
 
-    error.reset(make_child_key(&parent_key, 0, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_child_key(&parent_key, 0, nullptr));
 }
 
 GTEST_TEST(KeysTestInvalidArgs, make_user_id_from_master_key)

--- a/multy_test/test_mnemonic.cpp
+++ b/multy_test/test_mnemonic.cpp
@@ -81,19 +81,18 @@ TEST_P(MnemonicTestValidCasesP, Test)
         return result_size;
     };
     auto entropy_source = EntropySource{(void*)&entropy, fill_entropy};
-    error.reset(make_mnemonic(entropy_source, reset_sp(mnemonic_str)));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(make_mnemonic(entropy_source, reset_sp(mnemonic_str)));
     EXPECT_NE(nullptr, mnemonic_str);
 
     EXPECT_STREQ(expected_mnemonic.c_str(), mnemonic_str.get());
 
     BinaryDataPtr seed;
-    error.reset(make_seed(expected_mnemonic.c_str(), "TREZOR", reset_sp(seed)));
+    HANDLE_ERROR(make_seed(expected_mnemonic.c_str(), "TREZOR", reset_sp(seed)));
     ASSERT_NE(nullptr, seed);
     EXPECT_EQ(as_binary_data(expected_seed), *seed);
 
     ConstCharPtr dictionary;
-    error.reset(mnemonic_get_dictionary(reset_sp(dictionary)));
+    HANDLE_ERROR(mnemonic_get_dictionary(reset_sp(dictionary)));
     ASSERT_NE(nullptr, dictionary);
     ASSERT_NE(0, strlen(dictionary.get()));
 }
@@ -101,18 +100,17 @@ TEST_P(MnemonicTestValidCasesP, Test)
 GTEST_TEST(MnemonicTest, empty_null_password)
 {
     ConstCharPtr mnemonic_str;
-    ErrorPtr error;
 
-    error.reset(
+    HANDLE_ERROR(
             make_mnemonic(make_dummy_entropy_source(), reset_sp(mnemonic_str)));
     ASSERT_NE(nullptr, mnemonic_str);
 
     BinaryDataPtr empty_pass_seed;
-    error.reset(make_seed(mnemonic_str.get(), "", reset_sp(empty_pass_seed)));
+    HANDLE_ERROR(make_seed(mnemonic_str.get(), "", reset_sp(empty_pass_seed)));
     ASSERT_NE(nullptr, empty_pass_seed);
 
     BinaryDataPtr null_pass_seed;
-    error.reset(
+    HANDLE_ERROR(
             make_seed(mnemonic_str.get(), nullptr, reset_sp(null_pass_seed)));
     ASSERT_NE(nullptr, null_pass_seed);
 
@@ -133,37 +131,29 @@ GTEST_TEST(MnemonicTest, mnemonic_get_dictionary)
 GTEST_TEST(MnemonicTestInvalidArgs, make_mnemonic)
 {
     ConstCharPtr mnemonic_str;
-    ErrorPtr error;
 
-    error.reset(
+    EXPECT_ERROR(
             make_mnemonic(
                     EntropySource{nullptr, nullptr}, reset_sp(mnemonic_str)));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, mnemonic_str);
 
-    error.reset(make_mnemonic(make_dummy_entropy_source(), nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_mnemonic(make_dummy_entropy_source(), nullptr));
 }
 
 GTEST_TEST(MnemonicTestInvalidArgs, make_seed)
 {
     BinaryDataPtr binary_data;
-    ErrorPtr error;
 
-    error.reset(make_seed(nullptr, "pass", reset_sp(binary_data)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_seed(nullptr, "pass", reset_sp(binary_data)));
     EXPECT_EQ(nullptr, binary_data);
 
-    error.reset(make_seed("mnemonic", nullptr, reset_sp(binary_data)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_seed("mnemonic", nullptr, reset_sp(binary_data)));
     EXPECT_EQ(nullptr, binary_data);
 
-    error.reset(make_seed("mnemonic", "pass", nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_seed("mnemonic", "pass", nullptr));
 
     // Invalid mnemonic value
-    error.reset(make_seed("mnemonic", "pass", reset_sp(binary_data)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(make_seed("mnemonic", "pass", reset_sp(binary_data)));
     EXPECT_EQ(nullptr, binary_data);
 }
 
@@ -175,21 +165,16 @@ GTEST_TEST(MnemonicTestInvalidArgs, seed_to_string)
     const BinaryData zero_len_data{nullptr, 0};
 
     ConstCharPtr seed_str;
-    ErrorPtr error;
 
-    error.reset(seed_to_string(nullptr, reset_sp(seed_str)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(seed_to_string(nullptr, reset_sp(seed_str)));
     EXPECT_EQ(nullptr, seed_str);
 
-    error.reset(seed_to_string(&data, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(seed_to_string(&data, nullptr));
 
-    error.reset(seed_to_string(&null_data, reset_sp(seed_str)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(seed_to_string(&null_data, reset_sp(seed_str)));
     EXPECT_EQ(nullptr, seed_str);
 
-    error.reset(seed_to_string(&zero_len_data, reset_sp(seed_str)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(seed_to_string(&zero_len_data, reset_sp(seed_str)));
     EXPECT_EQ(nullptr, seed_str);
 }
 

--- a/multy_test/test_properties.cpp
+++ b/multy_test/test_properties.cpp
@@ -31,17 +31,9 @@ using namespace multy_core::internal;
 using namespace test_utility;
 }
 
-#define ASSERT_ERROR(statement)                                                \
-    do                                                                         \
-    {                                                                          \
-        ErrorPtr error(statement);                                             \
-        SCOPED_TRACE(#statement);                                              \
-        ASSERT_NE(nullptr, error);                                             \
-    } while (false)
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_set_int32_value)
 {
-    //    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_property = 0;
 
@@ -61,61 +53,49 @@ GTEST_TEST(PropertiesTestInvalidArgs, properties_set_int32_value)
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_set_string_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     std::string value_property = "2";
 
-    error.reset(properties_set_string_value(&properties, "v", "1"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "v", "1"));
 
     properties.bind_property("v", &value_property);
 
-    error.reset(properties_set_string_value(&properties, "v", nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "v", nullptr));
     EXPECT_STREQ("2", value_property.c_str());
 
-    error.reset(properties_set_string_value(&properties, "", "1"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "", "1"));
     EXPECT_STREQ("2", value_property.c_str());
 
-    error.reset(properties_set_string_value(&properties, nullptr, "1"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, nullptr, "1"));
     EXPECT_STREQ("2", value_property.c_str());
 
-    error.reset(properties_set_string_value(nullptr, "v", "1"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(nullptr, "v", "1"));
     EXPECT_STREQ("2", value_property.c_str());
 }
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_set_big_int_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     BigInt amount_property(0);
     const BigInt invalid_amount(1);
 
-    error.reset(properties_set_big_int_value(&properties, "v", &invalid_amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(&properties, "v", &invalid_amount));
 
     properties.bind_property("v", &amount_property);
 
-    error.reset(properties_set_big_int_value(&properties, "", &invalid_amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(&properties, "", &invalid_amount));
     EXPECT_STREQ("0", amount_property.get_value().c_str());
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_big_int_value(&properties, nullptr, &invalid_amount));
-    EXPECT_NE(nullptr, error);
     EXPECT_STREQ("0", amount_property.get_value().c_str());
 
-    error.reset(properties_set_big_int_value(nullptr, "v", &invalid_amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(nullptr, "v", &invalid_amount));
     EXPECT_STREQ("0", amount_property.get_value().c_str());
 }
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_set_binary_data_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     const unsigned char data_2_vals[] = {4U, 2U};
     BinaryDataPtr binaty_data_property;
@@ -123,33 +103,28 @@ GTEST_TEST(PropertiesTestInvalidArgs, properties_set_binary_data_value)
     BinaryDataPtr binary_data_check_not_nullptr(
             make_clone(BinaryData{data_2_vals, 2}));
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_binary_data_value(&properties, "v", &binary_data2));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, binaty_data_property);
 
     properties.bind_property("v", &binaty_data_property);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_binary_data_value(
                     &properties, nullptr, &binary_data2));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, binaty_data_property);
 
-    error.reset(properties_set_binary_data_value(nullptr, "v", &binary_data2));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_binary_data_value(nullptr, "v", &binary_data2));
     EXPECT_EQ(nullptr, binaty_data_property);
 
     properties.bind_property("nv", &binary_data_check_not_nullptr);
 
-    error.reset(properties_set_binary_data_value(&properties, "nv", nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_binary_data_value(&properties, "nv", nullptr));
     EXPECT_NE(nullptr, binary_data_check_not_nullptr);
 }
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_set_private_key_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     PrivateKeyPtr priv_key_property;
     PrivateKeyPtr priv_key_property1;
@@ -163,91 +138,74 @@ GTEST_TEST(PropertiesTestInvalidArgs, properties_set_private_key_value)
 
     priv_key_property1 = account1->get_private_key();
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     &properties, "v", priv_key_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, priv_key_property);
 
     properties.bind_property("v", &priv_key_property);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     &properties, nullptr, priv_key_property1.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, priv_key_property);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     nullptr, "v", priv_key_property1.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, priv_key_property);
 
     properties.bind_property("vn", &priv_key_property1);
 
-    error.reset(properties_set_private_key_value(&properties, "vn", nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_private_key_value(&properties, "vn", nullptr));
     EXPECT_NE(nullptr, priv_key_property1);
 }
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_reset_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_property = 1;
 
     properties.bind_property("v", &int_property);
 
-    error.reset(properties_reset_value(&properties, ""));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_reset_value(&properties, ""));
     EXPECT_EQ(1, int_property);
 
-    error.reset(properties_reset_value(&properties, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_reset_value(&properties, nullptr));
     EXPECT_EQ(1, int_property);
 
-    error.reset(properties_reset_value(nullptr, "v"));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_reset_value(nullptr, "v"));
     EXPECT_EQ(1, int_property);
 }
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_validate)
 {
-    ErrorPtr error;
-
-    error.reset(properties_validate(nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_validate(nullptr));
 }
 
 GTEST_TEST(PropertiesTestInvalidArgs, properties_get_specification)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     ConstCharPtr specification;
 
-    error.reset(properties_get_specification(&properties, nullptr));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_get_specification(&properties, nullptr));
 
-    error.reset(properties_get_specification(nullptr, reset_sp(specification)));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_get_specification(nullptr, reset_sp(specification)));
 }
 
 GTEST_TEST(PropertiesTestInvalidValue, properties_validate)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_property = 1;
 
     properties.bind_property("v", &int_property);
     properties_reset_value(&properties, "v");
 
-    error.reset(properties_validate(&properties));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_validate(&properties));
 }
 
 GTEST_TEST(PropertiesTestInvalidType, int32_properties)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_value = 1;
     const std::string str = "0";
@@ -268,30 +226,25 @@ GTEST_TEST(PropertiesTestInvalidType, int32_properties)
 
     properties.bind_property("v", &int_value);
 
-    error.reset(properties_set_string_value(&properties, "v", str.c_str()));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "v", str.c_str()));
     EXPECT_EQ(1, int_value);
 
-    error.reset(properties_set_big_int_value(&properties, "v", &amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(&properties, "v", &amount));
     EXPECT_EQ(1, int_value);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_binary_data_value(
                     &properties, "v", binaty_data_4_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(1, int_value);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     &properties, "v", priv_key_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(1, int_value);
 }
 
 GTEST_TEST(PropertiesTestInvalidType, String_properties)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     const int32_t int_value = 1;
     std::string str = "0";
@@ -312,30 +265,25 @@ GTEST_TEST(PropertiesTestInvalidType, String_properties)
 
     properties.bind_property("v", &str);
 
-    error.reset(properties_set_int32_value(&properties, "v", int_value));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_int32_value(&properties, "v", int_value));
     EXPECT_EQ("0", str);
 
-    error.reset(properties_set_big_int_value(&properties, "v", &amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(&properties, "v", &amount));
     EXPECT_EQ("0", str);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_binary_data_value(
                     &properties, "v", binaty_data_4_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ("0", str);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     &properties, "v", priv_key_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ("0", str);
 }
 
 GTEST_TEST(PropertiesTestInvalidType, Amount_properties)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     const std::string str = "0";
     const int32_t int_value = 1;
@@ -356,30 +304,25 @@ GTEST_TEST(PropertiesTestInvalidType, Amount_properties)
 
     properties.bind_property("v", &amount);
 
-    error.reset(properties_set_int32_value(&properties, "v", int_value));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_int32_value(&properties, "v", int_value));
     EXPECT_STREQ("2", amount.get_value().c_str());
 
-    error.reset(properties_set_string_value(&properties, "v", str.c_str()));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "v", str.c_str()));
     EXPECT_STREQ("2", amount.get_value().c_str());
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_binary_data_value(
                     &properties, "v", binaty_data_4_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_STREQ("2", amount.get_value().c_str());
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     &properties, "v", priv_key_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_STREQ("2", amount.get_value().c_str());
 }
 
 GTEST_TEST(PropertiesTestInvalidType, BinaryData_properties)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     const std::string str = "0";
     const int32_t int_value = 1;
@@ -401,28 +344,23 @@ GTEST_TEST(PropertiesTestInvalidType, BinaryData_properties)
 
     properties.bind_property("v", &binaty_data_4_property);
 
-    error.reset(properties_set_int32_value(&properties, "v", int_value));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_int32_value(&properties, "v", int_value));
     EXPECT_EQ(reference_value, *binaty_data_4_property);
 
-    error.reset(properties_set_string_value(&properties, "v", str.c_str()));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "v", str.c_str()));
     EXPECT_EQ(reference_value, *binaty_data_4_property);
 
-    error.reset(properties_set_big_int_value(&properties, "v", &amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(&properties, "v", &amount));
     EXPECT_EQ(reference_value, *binaty_data_4_property);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_private_key_value(
                     &properties, "v", priv_key_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(reference_value, *binaty_data_4_property);
 }
 
 GTEST_TEST(PropertiesTestInvalidType, PublicKey_properties)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     const std::string str = "0";
     const int32_t int_value = 1;
@@ -436,68 +374,57 @@ GTEST_TEST(PropertiesTestInvalidType, PublicKey_properties)
 
     properties.bind_property("v", &priv_key_property);
 
-    error.reset(properties_set_int32_value(&properties, "v", int_value));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_int32_value(&properties, "v", int_value));
     EXPECT_EQ(nullptr, priv_key_property);
 
-    error.reset(properties_set_string_value(&properties, "v", str.c_str()));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_string_value(&properties, "v", str.c_str()));
     EXPECT_EQ(nullptr, priv_key_property);
 
-    error.reset(properties_set_big_int_value(&properties, "v", &amount));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_set_big_int_value(&properties, "v", &amount));
     EXPECT_EQ(nullptr, priv_key_property);
 
-    error.reset(
+    EXPECT_ERROR(
             properties_set_binary_data_value(
                     &properties, "v", binaty_data_4_property.get()));
-    EXPECT_NE(nullptr, error);
     EXPECT_EQ(nullptr, priv_key_property);
 }
 
 GTEST_TEST(PropertiesTest, properties_set_int32_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_property = 0;
 
     properties.bind_property("v", &int_property);
 
-    error.reset(properties_set_int32_value(&properties, "v", 42));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(properties_set_int32_value(&properties, "v", 42));
     EXPECT_EQ(42, int_property);
 }
 
 GTEST_TEST(PropertiesTest, properties_set_string_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     std::string str = "2";
 
     properties.bind_property("v", &str);
 
-    error.reset(properties_set_string_value(&properties, "v", "42"));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(properties_set_string_value(&properties, "v", "42"));
     EXPECT_STREQ("42", str.c_str());
 }
 
 GTEST_TEST(PropertiesTest, properties_set_big_int_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     BigInt amount(0);
     const BigInt amount1(1);
 
     properties.bind_property("v", &amount);
 
-    error.reset(properties_set_big_int_value(&properties, "v", &amount1));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(properties_set_big_int_value(&properties, "v", &amount1));
     EXPECT_STREQ("1", amount.get_value().c_str());
 }
 
 GTEST_TEST(PropertiesTest, properties_set_binary_data_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     const unsigned char data_4_vals[] = {1U, 2U, 3U, 4U};
     const unsigned char data_2_vals[] = {4U, 2U};
@@ -509,22 +436,19 @@ GTEST_TEST(PropertiesTest, properties_set_binary_data_value)
 
     properties.bind_property("v", &binaty_data_property);
 
-    error.reset(
+    HANDLE_ERROR(
             properties_set_binary_data_value(
                     &properties, "v", binaty_data_2_property.get()));
-    EXPECT_EQ(nullptr, error);
     EXPECT_EQ(reference_data_2_value, *binaty_data_property);
 
-    error.reset(
+    HANDLE_ERROR(
             properties_set_binary_data_value(
                     &properties, "v", binaty_data_property.get()));
-    EXPECT_EQ(nullptr, error);
     EXPECT_NE(reference_data_4_value, *binaty_data_property);
 }
 
 GTEST_TEST(PropertiesTest, properties_set_private_key_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     PrivateKeyPtr priv_key_property;
 
@@ -539,48 +463,40 @@ GTEST_TEST(PropertiesTest, properties_set_private_key_value)
 
     properties.bind_property("v", &priv_key_property);
 
-    error.reset(
+    HANDLE_ERROR(
             properties_set_private_key_value(
                     &properties, "v", priv_key_property1.get()));
-    EXPECT_EQ(nullptr, error);
     EXPECT_EQ(*priv_key_property, *priv_key_property1);
 }
 
 GTEST_TEST(PropertiesTest, properties_reset_value)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_property = 1;
     properties.bind_property("v", &int_property);
 
-    error.reset(properties_reset_value(&properties, "v"));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(properties_reset_value(&properties, "v"));
     EXPECT_FALSE(properties.get_property("v").is_set());
 }
 
 GTEST_TEST(PropertiesTest, properties_validate)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     int32_t int_property = 1;
 
-    error.reset(properties_validate(&properties));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(properties_validate(&properties));
 
     properties.bind_property("v", &int_property);
     properties.set_property_value("v", 5);
 
-    error.reset(properties_validate(&properties));
-    EXPECT_EQ(nullptr, error);
+    HANDLE_ERROR(properties_validate(&properties));
 
     properties.reset_property("v");
-    error.reset(properties_validate(&properties));
-    EXPECT_NE(nullptr, error);
+    EXPECT_ERROR(properties_validate(&properties));
 }
 
 GTEST_TEST(PropertiesTest, properties_get_specification)
 {
-    ErrorPtr error;
     Properties properties(ERROR_SCOPE_GENERIC, "TEST");
     ConstCharPtr specification;
     int int_property = 3;
@@ -588,10 +504,8 @@ GTEST_TEST(PropertiesTest, properties_get_specification)
     properties.bind_property("MANY_LONG_STRING_FOR_CHECKING", &int_property);
     properties.set_property_value("MANY_LONG_STRING_FOR_CHECKING", 5);
 
-    error.reset(
+    HANDLE_ERROR(
             properties_get_specification(&properties, reset_sp(specification)));
-    EXPECT_EQ(nullptr, error);
-
     EXPECT_NE(
             nullptr,
             strstr(specification.get(), "MANY_LONG_STRING_FOR_CHECKING"));

--- a/multy_test/utility.cpp
+++ b/multy_test/utility.cpp
@@ -8,6 +8,7 @@
 
 #include "multy_core/account.h"
 #include "multy_core/common.h"
+#include "multy_core/src/api/big_int_impl.h"
 #include "multy_core/src/api/key_impl.h"
 
 #include "multy_test/value_printers.h"
@@ -41,6 +42,67 @@ size_t dummy_fill_entropy(void*, size_t size, void* dest)
 
 namespace test_utility
 {
+
+const uint64_t SATOSHIS_IN_BTC = 100L*1000*1000;
+const uint64_t WEIS_IN_ETH = 1000L*1000*1000*1000*1000*1000;
+const uint64_t WEIS_IN_GWEI = 1000L*1000*1000;
+
+
+// Returns Satoshi corresponding to fractional amount of BTC.
+BigInt operator"" _BTC(const long double btc)
+{
+    const double satoshi = btc * SATOSHIS_IN_BTC;
+    if (satoshi < 0)
+    {
+        THROW_EXCEPTION("Value is too low.");
+    }
+    if(satoshi > std::numeric_limits<uint64_t>::max())
+    {
+        THROW_EXCEPTION("Value is too high.");
+    }
+
+    return BigInt(static_cast<uint64_t>(satoshi));
+}
+
+BigInt operator"" _SATOSHI(const unsigned long long int satoshi)
+{
+    return BigInt(static_cast<uint64_t>(satoshi));
+}
+
+BigInt operator "" _ETH(const long double eth)
+{
+    const double wei = eth * WEIS_IN_ETH;
+    if (wei < 0)
+    {
+        THROW_EXCEPTION("Value is too low.");
+    }
+    if(wei > std::numeric_limits<uint64_t>::max())
+    {
+        THROW_EXCEPTION("Value is too high.");
+    }
+
+    return BigInt(static_cast<uint64_t>(wei));
+}
+
+BigInt operator "" _GWEI(const long double gwei)
+{
+    const double wei = gwei * WEIS_IN_GWEI;
+    if (wei < 0)
+    {
+        THROW_EXCEPTION("Value is too low.");
+    }
+    if(wei > std::numeric_limits<uint64_t>::max())
+    {
+        THROW_EXCEPTION("Value is too high.");
+    }
+
+    return BigInt(static_cast<uint64_t>(wei));
+}
+
+BigInt operator "" _WEI(const unsigned long long int wei)
+{
+    return BigInt(static_cast<uint64_t>(wei));
+}
 
 bytes from_hex(const char* hex_str)
 {

--- a/multy_test/utility.h
+++ b/multy_test/utility.h
@@ -34,6 +34,13 @@
         EXPECT_NE(nullptr, error);                                             \
     } while (0)
 
+#define ASSERT_ERROR(statement)                                                \
+    do                                                                         \
+    {                                                                          \
+        multy_core::internal::ErrorPtr error(statement);                                             \
+        ASSERT_NE(nullptr, error);                                             \
+    } while (false)
+
 #define EXPECT_ERROR_WITH_CODE(statement, error_code)                          \
     do                                                                         \
     {                                                                          \
@@ -78,6 +85,11 @@ bool blockchain_can_derive_address_from_private_key(Blockchain blockchain);
 
 std::string minify_json(const std::string &input_json);
 
+BigInt operator"" _BTC(const long double btc);
+BigInt operator"" _SATOSHI(const unsigned long long int btc);
+BigInt operator "" _ETH(const long double eth);
+BigInt operator "" _GWEI(const long double gwei);
+BigInt operator "" _WEI(const unsigned long long int wei);
 } // test_utility
 
 bool operator==(const PrivateKey& lhs, const PrivateKey& rhs);


### PR DESCRIPTION
    * Refactor multy_test Add a user-defined literal suffixes _BTC, _SATOSHI and _ETH, _GWEI, _WEI that would convert long double amount of BTC or ETH into Satoshi (or Wei).
    * Refactor code with HANDLE_ERROR and EXPECT_ERROR
    * Use TransactionTemplate for bitcoin test transactions where possible