### PR TITLE
MUL-1253: Serialize transactions in node native format.

### DIFF
--- a/multy_core/src/api/transaction.cpp
+++ b/multy_core/src/api/transaction.cpp
@@ -24,10 +24,11 @@ Error* make_transaction(const Account* account, Transaction** new_transaction)
 
     try
     {
-        *new_transaction = get_blockchain(account->get_blockchain_type().blockchain)
-                .make_transaction(*account).release();
+        *new_transaction = get_blockchain(*account).make_transaction(*account)
+                .release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_TRANSACTION);
+
     OUT_CHECK_OBJECT(*new_transaction);
 
     return nullptr;
@@ -147,6 +148,7 @@ Error* transaction_estimate_total_fee(
         *out_fee_estimate = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_TRANSACTION);
+
     OUT_CHECK_OBJECT(*out_fee_estimate);
 
     return nullptr;
@@ -164,6 +166,7 @@ Error* transaction_get_total_fee(const Transaction* transaction, BigInt** out_to
         *out_total_fee = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_TRANSACTION);
+
     OUT_CHECK_OBJECT(*out_total_fee);
 
     return nullptr;
@@ -183,6 +186,7 @@ Error* transaction_get_total_spent(
         *out_total_spent = result.release();
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_TRANSACTION);
+
     OUT_CHECK_OBJECT(*out_total_spent);
 
     return nullptr;
@@ -211,6 +215,28 @@ Error* transaction_serialize(
     try
     {
         *out_serialized_transaction = transaction->serialize().release();
+    }
+    CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_TRANSACTION);
+    OUT_CHECK(*out_serialized_transaction);
+
+    return nullptr;
+}
+
+Error* transaction_serialize_encoded(
+        Transaction* transaction,
+        const char** out_serialized_transaction)
+{
+    ARG_CHECK_OBJECT(transaction);
+    ARG_CHECK(out_serialized_transaction);
+
+    try
+    {
+        const auto serialized_transaction = transaction->serialize();
+        const auto& blockchain_facade = get_blockchain(*transaction);
+
+        *out_serialized_transaction = copy_string(
+                blockchain_facade.encode_serialized_transaction(
+                        *serialized_transaction));
     }
     CATCH_EXCEPTION_RETURN_ERROR(ERROR_SCOPE_TRANSACTION);
 

--- a/multy_core/src/bitcoin/bitcoin_facade.cpp
+++ b/multy_core/src/bitcoin/bitcoin_facade.cpp
@@ -15,6 +15,8 @@
 #include "multy_core/src/bitcoin/bitcoin_transaction.h"
 #include "multy_core/src/utility.h"
 
+#include "multy_core/src/codec.h"
+
 namespace
 {
 using namespace multy_core::internal;
@@ -55,7 +57,7 @@ HDAccountPtr BitcoinFacade::make_hd_account(
         BlockchainType blockchain_type,
         uint32_t account_type,
         const ExtendedKey& master_key,
-        uint32_t index)
+        uint32_t index) const
 {
     return HDAccountPtr(new BitcoinHDAccount(
             blockchain_type,
@@ -67,7 +69,7 @@ HDAccountPtr BitcoinFacade::make_hd_account(
 AccountPtr BitcoinFacade::make_account(
         BlockchainType blockchain_type,
         uint32_t account_type,
-        const char* serialized_private_key)
+        const char* serialized_private_key) const
 {
     AccountPtr account = make_bitcoin_account(serialized_private_key,
             to_bitcoin_account_type(account_type));
@@ -81,12 +83,12 @@ AccountPtr BitcoinFacade::make_account(
     return account;
 }
 
-TransactionPtr BitcoinFacade::make_transaction(const Account& account)
+TransactionPtr BitcoinFacade::make_transaction(const Account& account) const
 {
     return TransactionPtr(new BitcoinTransaction(account.get_blockchain_type()));
 }
 
-void BitcoinFacade::validate_address(BlockchainType blockchain_type, const char* address)
+void BitcoinFacade::validate_address(BlockchainType blockchain_type, const char* address) const
 {
     INVARIANT(address);
 
@@ -105,6 +107,12 @@ void BitcoinFacade::validate_address(BlockchainType blockchain_type, const char*
                 << " Requested: " << blockchain_type.net_type
                 << ", address net type:" << net_type;
     }
+}
+
+std::string BitcoinFacade::encode_serialized_transaction(
+        const BinaryData& serialized_transaction) const
+{
+    return encode(serialized_transaction, CODEC_HEX);
 }
 
 } // internal

--- a/multy_core/src/bitcoin/bitcoin_facade.h
+++ b/multy_core/src/bitcoin/bitcoin_facade.h
@@ -9,6 +9,15 @@
 
 #include "multy_core/src/blockchain_facade_base.h"
 
+#include "multy_core/binary_data.h"
+#include "multy_core/blockchain.h"
+
+#include <string>
+#include <stdint.h>
+
+struct Account;
+struct BinaryData;
+
 namespace multy_core
 {
 namespace internal
@@ -24,15 +33,18 @@ public:
             BlockchainType blockchain_type,
             uint32_t account_type,
             const ExtendedKey& master_key,
-            uint32_t index) override;
+            uint32_t index) const override;
 
     AccountPtr make_account(
             BlockchainType blockchain_type,
             uint32_t account_type,
-            const char* serialized_private_key) override;
+            const char* serialized_private_key) const override;
 
-    TransactionPtr make_transaction(const Account&) override;
-    void validate_address(BlockchainType blockchain_type, const char*) override;
+    TransactionPtr make_transaction(const Account&) const override;
+    void validate_address(BlockchainType blockchain_type, const char*) const override;
+
+    std::string encode_serialized_transaction(
+            const BinaryData& serialized_transaction) const override;
 };
 
 } // internal

--- a/multy_core/src/bitcoin/bitcoin_key.h
+++ b/multy_core/src/bitcoin/bitcoin_key.h
@@ -53,6 +53,7 @@ struct BitcoinPrivateKey : public PrivateKey
     BitcoinPrivateKey(const BinaryData& data,
             BitcoinNetType net_type,
             PublicKeyFormat public_key_format);
+
     ~BitcoinPrivateKey();
 
     std::string to_string() const override;

--- a/multy_core/src/blockchain_facade_base.cpp
+++ b/multy_core/src/blockchain_facade_base.cpp
@@ -20,6 +20,11 @@ namespace multy_core
 namespace internal
 {
 
+BlockchainFacadeBase& get_blockchain(BlockchainType blockchain_type)
+{
+    return get_blockchain(blockchain_type.blockchain);
+}
+
 BlockchainFacadeBase& get_blockchain(Blockchain blockchain_type)
 {
     return BlockchainFacadeRegistry::get_instance().get_blockchain(blockchain_type);

--- a/multy_core/src/blockchain_facade_base.h
+++ b/multy_core/src/blockchain_facade_base.h
@@ -33,19 +33,30 @@ public:
             BlockchainType blockchain_type,
             uint32_t account_type,
             const ExtendedKey& master_key,
-            uint32_t index) = 0;
+            uint32_t index) const = 0;
 
     virtual AccountPtr make_account(
             BlockchainType blockchain_type,
             uint32_t account_type,
-            const char* serialized_private_key) = 0;
+            const char* serialized_private_key) const = 0;
 
-    virtual TransactionPtr make_transaction(const Account&) = 0;
+    virtual TransactionPtr make_transaction(const Account&) const = 0;
 
-    virtual void validate_address(BlockchainType, const char* ) = 0;
+    virtual void validate_address(BlockchainType, const char*) const = 0;
+
+    virtual std::string encode_serialized_transaction(
+            const BinaryData& serialized_transaction) const = 0;
 };
 
+BlockchainFacadeBase& get_blockchain(BlockchainType blockchain_type);
 BlockchainFacadeBase& get_blockchain(Blockchain blockchain_type);
+
+// Convinience method for getting blockchain from Account and Transaction
+template <typename T>
+BlockchainFacadeBase& get_blockchain(const T& object)
+{
+    return get_blockchain(object.get_blockchain_type());
+}
 
 class BlockchainFacadeRegistry
 {

--- a/multy_core/src/ethereum/ethereum_facade.cpp
+++ b/multy_core/src/ethereum/ethereum_facade.cpp
@@ -12,6 +12,8 @@
 #include "multy_core/src/exception.h"
 #include "multy_core/src/exception_stream.h"
 
+#include "multy_core/src/codec.h"
+
 namespace
 {
 
@@ -44,7 +46,7 @@ HDAccountPtr EthereumFacade::make_hd_account(
         BlockchainType blockchain_type,
         uint32_t account_type,
         const ExtendedKey& master_key,
-        uint32_t index)
+        uint32_t index) const
 {
     validate_ethereum_account_type(account_type);
 
@@ -54,22 +56,28 @@ HDAccountPtr EthereumFacade::make_hd_account(
 AccountPtr EthereumFacade::make_account(
         BlockchainType blockchain_type,
         uint32_t account_type,
-        const char* serialized_private_key)
+        const char* serialized_private_key) const
 {
     validate_ethereum_account_type(account_type);
 
     return make_ethereum_account(blockchain_type, serialized_private_key);
 }
 
-TransactionPtr EthereumFacade::make_transaction(const Account& account)
+TransactionPtr EthereumFacade::make_transaction(const Account& account) const
 {
     return TransactionPtr(new EthereumTransaction(account));
 }
 
 void EthereumFacade::validate_address(
-        BlockchainType, const char* address)
+        BlockchainType, const char* address) const
 {
     ethereum_parse_address(address);
+}
+
+std::string EthereumFacade::encode_serialized_transaction(
+        const BinaryData& serialized_transaction) const
+{
+    return "0x" + encode(serialized_transaction, CODEC_HEX);
 }
 
 } // namespace internal

--- a/multy_core/src/ethereum/ethereum_facade.h
+++ b/multy_core/src/ethereum/ethereum_facade.h
@@ -9,6 +9,15 @@
 
 #include "multy_core/src/blockchain_facade_base.h"
 
+#include "multy_core/binary_data.h"
+#include "multy_core/blockchain.h"
+
+#include <string>
+#include <stdint.h>
+
+struct Account;
+struct BinaryData;
+
 namespace multy_core
 {
 namespace internal
@@ -24,16 +33,19 @@ public:
             BlockchainType blockchain_type,
             uint32_t account_type,
             const ExtendedKey& master_key,
-            uint32_t index) override;
+            uint32_t index) const override;
 
     AccountPtr make_account(
             BlockchainType blockchain_type,
             uint32_t account_type,
-            const char* serialized_private_key) override;
+            const char* serialized_private_key) const override;
 
-    TransactionPtr make_transaction(const Account&) override;
+    TransactionPtr make_transaction(const Account&) const override;
     void validate_address(BlockchainType blockchain_type,
-            const char* address) override;
+            const char* address) const override;
+
+    std::string encode_serialized_transaction(
+                const BinaryData& serialized_transaction) const override;
 };
 
 } // internal

--- a/multy_core/src/golos/golos_facade.cpp
+++ b/multy_core/src/golos/golos_facade.cpp
@@ -49,7 +49,7 @@ HDAccountPtr GolosFacade::make_hd_account(
         BlockchainType blockchain_type,
         uint32_t account_type,
         const ExtendedKey& master_key,
-        uint32_t index)
+        uint32_t index) const
 {
     validate_golos_account_type(account_type);
 
@@ -59,20 +59,20 @@ HDAccountPtr GolosFacade::make_hd_account(
 AccountPtr GolosFacade::make_account(
         BlockchainType blockchain_type,
         uint32_t account_type,
-        const char* serialized_private_key)
+        const char* serialized_private_key) const
 {
     validate_golos_account_type(account_type);
 
     return make_golos_account(blockchain_type, serialized_private_key);
 }
 
-TransactionPtr GolosFacade::make_transaction(const Account& account)
+TransactionPtr GolosFacade::make_transaction(const Account& account) const
 {
     return TransactionPtr(new GolosTransaction(account.get_blockchain_type()));
 }
 
 void GolosFacade::validate_address(
-        BlockchainType, const char* address)
+        BlockchainType, const char* address) const
 {
     INVARIANT(address != nullptr);
 
@@ -93,6 +93,15 @@ void GolosFacade::validate_address(
         THROW_EXCEPTION2(ERROR_INVALID_ADDRESS, "Invalid Golos account address.")
                 << "Should match pattern: \"" << GOLOS_ACCOUNT_NAME_RE << "\".";
     }
+}
+
+std::string GolosFacade::encode_serialized_transaction(
+        const BinaryData& serialized_transaction) const
+{
+    INVARIANT(serialized_transaction.data != nullptr);
+    INVARIANT(serialized_transaction.len != 0);
+
+    return std::string(reinterpret_cast<const char*>(serialized_transaction.data), serialized_transaction.len);
 }
 
 } // namespace internal

--- a/multy_core/src/golos/golos_facade.h
+++ b/multy_core/src/golos/golos_facade.h
@@ -9,6 +9,15 @@
 
 #include "multy_core/src/blockchain_facade_base.h"
 
+#include "multy_core/binary_data.h"
+#include "multy_core/blockchain.h"
+
+#include <string>
+#include <stdint.h>
+
+struct Account;
+struct BinaryData;
+
 namespace multy_core
 {
 namespace internal
@@ -24,15 +33,18 @@ public:
             BlockchainType blockchain_type,
             uint32_t account_type,
             const ExtendedKey& master_key,
-            uint32_t index) override;
+            uint32_t index) const override;
 
     AccountPtr make_account(
             BlockchainType blockchain_type,
             uint32_t account_type,
-            const char* serialized_private_key) override;
+            const char* serialized_private_key) const override;
 
-    TransactionPtr make_transaction(const Account&) override;
-    void validate_address(BlockchainType blockchain_type, const char*) override;
+    TransactionPtr make_transaction(const Account&) const override;
+    void validate_address(BlockchainType blockchain_type, const char*) const override;
+
+    std::string encode_serialized_transaction(
+            const BinaryData& serialized_transaction) const override;
 };
 
 } // internal

--- a/multy_core/transaction.h
+++ b/multy_core/transaction.h
@@ -57,7 +57,7 @@ MULTY_CORE_API struct Error* transaction_get_properties(
  * @param out_fee_estimation - fee estimation in transaction currency (BTC, ETHC, etc.).
  *
  * Please note that final fee value might differ from this estimation.
- * @throw Exception if any of the required transaction (or fee) properties are not set.
+ * @return Error if any of the required transaction (or fee) properties are not set.
  */
 MULTY_CORE_API struct Error* transaction_estimate_total_fee(
         const struct Transaction* transaction,
@@ -93,9 +93,20 @@ MULTY_CORE_API struct Error* transaction_get_total_spent(
 MULTY_CORE_API struct Error* transaction_update(
         struct Transaction* transaction);
 
+
 MULTY_CORE_API struct Error* transaction_serialize(
         struct Transaction* transaction,
-        struct BinaryData** out_serialized_transaction);
+        BinaryData** out_serialized_transaction);
+
+/** Serialize transcation to a form accepted by node.
+ *
+ * @param transaction - input transaction object
+ * @param out_serialized_transaction - string that can be sent to node
+ * to actually make a transaction on a blockchain, MUST be freed by caller.
+ */
+MULTY_CORE_API struct Error* transaction_serialize_encoded(
+        struct Transaction* transaction,
+        const char** out_serialized_transaction);
 
 MULTY_CORE_API void free_transaction(struct Transaction* transaction);
 

--- a/multy_test/mocks.cpp
+++ b/multy_test/mocks.cpp
@@ -141,10 +141,11 @@ void TestTransaction::update()
 
 Transaction::BinaryDataPtr TestTransaction::serialize()
 {
-    return BinaryDataPtr(new BinaryData{nullptr, 0});
+    static const char TEST_TX[] = "TEST_TX";
+    return make_clone(as_binary_data(TEST_TX));
 }
 
-BigInt TestTransaction::estimate_total_fee(size_t sources_count, size_t destinations_count) const
+BigInt TestTransaction::estimate_total_fee(size_t /*sources_count*/, size_t /*destinations_count*/) const
 {
     return m_total;
 }

--- a/multy_test/test_bitcoin_transaction.cpp
+++ b/multy_test/test_bitcoin_transaction.cpp
@@ -678,9 +678,13 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet2_with_key_to_source)
         EXPECT_GE(max_total_fee, estimated_fee.get_value_as_uint64());
     }
 
-    ASSERT_EQ(as_binary_data(from_hex(
-            "010000000191a34273f5cb57244de3d7b27678b3ad385ac46c7df2c440f3f7b5ad23929748000000006a473044022064d09103c9d48c8b094db03227621ced41732a74963578d3495bac4f7f65b40e02201f2f7adf872c1de2af5027edefdf29379faf9fe8f5751015c974e064a9d9d6e0012102163387c2c86f897b8aef15ee24e1f135da70c52e7dde12c06e122891c704d694ffffffff014062b007000000001976a914d3f68b887224cabcc90a9581c7bbdace878666db88ac00000000")),
-            *serialied);
+    const char* TX = "010000000191a34273f5cb57244de3d7b27678b3ad385ac46c7df2c440f3f7b5ad23929748000000006a473044022064d09103c9d48c8b094db03227621ced41732a74963578d3495bac4f7f65b40e02201f2f7adf872c1de2af5027edefdf29379faf9fe8f5751015c974e064a9d9d6e0012102163387c2c86f897b8aef15ee24e1f135da70c52e7dde12c06e122891c704d694ffffffff014062b007000000001976a914d3f68b887224cabcc90a9581c7bbdace878666db88ac00000000";
+    ASSERT_EQ(as_binary_data(from_hex(TX)), *serialied);
+
+    ConstCharPtr serialized_encoded;
+    HANDLE_ERROR(transaction_serialize_encoded(transaction.get(),
+            reset_sp(serialized_encoded)));
+    ASSERT_STREQ(serialized_encoded.get(), TX);
 }
 
 GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet3)
@@ -740,10 +744,14 @@ GTEST_TEST(BitcoinTransactionTest, SmokeTest_testnet3)
     transaction->get_transaction_properties()
             .set_property_value("is_replaceable", 0);
 
+    const char* TX = "0100000001da1ca8202f16683e307b47fe4c9e65804569e4b50f84e14ed79b60e54a65ae13010000006b483045022100e217cfb5920878da55069a919029ab910ff106cfb20fd901e82de041b149d71902202756c5700377294837893cca854e60b6cca86423f4407b8faf92ff898aded00a012102163387c2c86f897b8aef15ee24e1f135da70c52e7dde12c06e122891c704d694ffffffff0300e1f505000000001976a91401de29d6f0aaf3467da7881a981c5c5ef90258bd88ac00e1f505000000001976a914323c1ea8756feaaaa85d0d0e51b0cc07b4c7ac5e88acc0878b3b000000001976a914d3f68b887224cabcc90a9581c7bbdace878666db88ac00000000";
     const BinaryDataPtr serialied = transaction->serialize();
-    ASSERT_EQ(as_binary_data(from_hex(
-            "0100000001da1ca8202f16683e307b47fe4c9e65804569e4b50f84e14ed79b60e54a65ae13010000006b483045022100e217cfb5920878da55069a919029ab910ff106cfb20fd901e82de041b149d71902202756c5700377294837893cca854e60b6cca86423f4407b8faf92ff898aded00a012102163387c2c86f897b8aef15ee24e1f135da70c52e7dde12c06e122891c704d694ffffffff0300e1f505000000001976a91401de29d6f0aaf3467da7881a981c5c5ef90258bd88ac00e1f505000000001976a914323c1ea8756feaaaa85d0d0e51b0cc07b4c7ac5e88acc0878b3b000000001976a914d3f68b887224cabcc90a9581c7bbdace878666db88ac00000000")),
-            *serialied);
+    ASSERT_EQ(as_binary_data(from_hex(TX)), *serialied);
+
+    ConstCharPtr serialized_encoded;
+    HANDLE_ERROR(transaction_serialize_encoded(transaction.get(),
+            reset_sp(serialized_encoded)));
+    ASSERT_STREQ(serialized_encoded.get(), TX);
 }
 
 GTEST_TEST(BitcoinTransactionTest, SmokeTest_with_many_input_from_one_addreses_testnet)

--- a/multy_test/test_ethereum_transaction.cpp
+++ b/multy_test/test_ethereum_transaction.cpp
@@ -91,13 +91,18 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_public_api)
         HANDLE_ERROR(properties_set_big_int_value(fee, "gas_limit", amount_gas_limit.get()));
     }
 
+    const char* TX = "f85f800182520994d1b48a11e2251555c3c6d8b93e13f9aa2f51ea1901802ba033de58162abbfdf1e744f5fee2b7a3c92691d9c59fc3f9ad2fa3fb946c8ea90aa0787abc84d20457c12fdcf62b612247fb34e397f6bdec64fc6a3bc9444df3e946";
+
     {
         BinaryDataPtr serialied;
         HANDLE_ERROR(transaction_serialize(transaction.get(), reset_sp(serialied)));
-        ASSERT_EQ(as_binary_data(from_hex("f85f800182520994d1b48a11e2251555c3c6d8b93e13f9aa2f51ea1901802ba033de58162abbfdf1e744f5fee2b7a3c92691d9c59fc3f9ad2fa3fb946c8ea90aa0787abc84d20457c12fdcf62b612247fb34e397f6bdec64fc6a3bc9444df3e946")),
-                  *serialied);
+        ASSERT_EQ(as_binary_data(from_hex(TX)), *serialied);
     }
 
+    ConstCharPtr serialized_encoded;
+    HANDLE_ERROR(transaction_serialize_encoded(transaction.get(),
+            reset_sp(serialized_encoded)));
+    ASSERT_STREQ(serialized_encoded.get(), (std::string("0x") + TX).c_str());
 }
 
 GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet1)
@@ -194,11 +199,14 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet2)
     const BinaryDataPtr serialied = transaction->serialize();
     std::cerr << "signed transaction:" << to_hex(*serialied) << "\n";
 
-    ASSERT_EQ(as_binary_data(from_hex(
-            "f86c04850f0000000082520994d1b48a11e2251555c3c6d8b93e13f9aa2f51ea19882000000000000000802ba0098ee502619d5ba29d66b6c510265142f46ee0399456be7afb63ceefac0bd17ea07c19cc4145471b31f90af07f554611ac535cd006f64fb2141f1ed7bea7150386")),
-            *serialied);
-}
+    const char* TX = "f86c04850f0000000082520994d1b48a11e2251555c3c6d8b93e13f9aa2f51ea19882000000000000000802ba0098ee502619d5ba29d66b6c510265142f46ee0399456be7afb63ceefac0bd17ea07c19cc4145471b31f90af07f554611ac535cd006f64fb2141f1ed7bea7150386";
+    ASSERT_EQ(as_binary_data(from_hex(TX)), *serialied);
 
+    ConstCharPtr serialized_encoded;
+    HANDLE_ERROR(transaction_serialize_encoded(transaction.get(),
+            reset_sp(serialized_encoded)));
+    ASSERT_STREQ(serialized_encoded.get(), (std::string("0x") + TX).c_str());
+}
 
 GTEST_TEST(EthereumTransactionTest, SmokeTest_testnet_withdata)
 {
@@ -717,7 +725,6 @@ GTEST_TEST(EthereumTransactionTest, SmokeTest_mainnet_ERC20_transfer)
     HANDLE_ERROR(transaction_set_message(transaction.get(), data.get()));
 
     const BinaryDataPtr serialied = transaction->serialize();
-
 
     // TXid: 0xbce2467f9bfc1cfe3e6f98f6429970bec200cc48bf4de18d5540e02be14e19fe
     ASSERT_EQ(as_binary_data(from_hex(

--- a/multy_test/test_transaction.cpp
+++ b/multy_test/test_transaction.cpp
@@ -100,7 +100,7 @@ GTEST_TEST(TransactionTestInvalidArgs, transaction_get_total_fee)
     TestTransaction transaction;
     BigIntPtr amount;
 
-    EXPECT_ERROR(transaction_get_total_fee(&transaction, nullptr ));
+    EXPECT_ERROR(transaction_get_total_fee(&transaction, nullptr));
 
     EXPECT_ERROR(transaction_get_total_fee(nullptr, reset_sp(amount)));
     EXPECT_EQ(nullptr, amount);
@@ -111,7 +111,7 @@ GTEST_TEST(TransactionTestInvalidArgs, transaction_get_total_spent)
     TestTransaction transaction;
     BigIntPtr amount;
 
-    EXPECT_ERROR(transaction_get_total_spent(&transaction, nullptr ));
+    EXPECT_ERROR(transaction_get_total_spent(&transaction, nullptr));
 
     EXPECT_ERROR(transaction_get_total_spent(nullptr, reset_sp(amount)));
     EXPECT_EQ(nullptr, amount);
@@ -122,8 +122,17 @@ GTEST_TEST(TransactionTestInvalidArgs, transaction_serialize)
     TestTransaction transaction;
     BinaryDataPtr binary_data;
 
-    EXPECT_ERROR(transaction_serialize(nullptr, reset_sp(binary_data) ));
+    EXPECT_ERROR(transaction_serialize(nullptr, reset_sp(binary_data)));
     EXPECT_ERROR(transaction_serialize(&transaction, nullptr));
+}
+
+GTEST_TEST(TransactionTestInvalidArgs, transaction_serialize_encoded)
+{
+    TestTransaction transaction;
+    ConstCharPtr serialized;
+
+    EXPECT_ERROR(transaction_serialize_encoded(nullptr, reset_sp(serialized)));
+    EXPECT_ERROR(transaction_serialize_encoded(&transaction, nullptr));
 }
 
 GTEST_TEST(TransactionTestInvalidArgs, transaction_set_message)
@@ -141,7 +150,6 @@ GTEST_TEST(TransactionTestInvalidArgs, transaction_update)
 {
     EXPECT_ERROR(transaction_update(nullptr));
 }
-
 
 GTEST_TEST(TransactionTest, make_transaction)
 {
@@ -224,6 +232,14 @@ GTEST_TEST(TransactionTest, transaction_serialize)
 
     HANDLE_ERROR(
             transaction_serialize(&transaction, reset_sp(serialize_binary_data)));
+}
+
+GTEST_TEST(TransactionTest, transaction_serialize_encoded)
+{
+    TestTransaction transaction;
+    ConstCharPtr serialized;
+
+    HANDLE_ERROR(transaction_serialize_encoded(&transaction, reset_sp(serialized)));
 }
 
 GTEST_TEST(TransactionTest, transaction_set_message)


### PR DESCRIPTION
Added API function transaction_serialize_encoded() that serializes transaction into node-native string;
Added tests to the new API function;
Updated Bitcoin and Ethereum tests to check for output of encode_serialized_transaction();